### PR TITLE
Add normalized context schema for ingestion

### DIFF
--- a/docs/context_schema.md
+++ b/docs/context_schema.md
@@ -2,97 +2,118 @@
 
 ## Overview
 
-The `ContextSnapshot` is the normalized data model ingested via the `/api/v1/context/ingest` endpoint. It aggregates contextual information from multiple sources (weather, calendar, news, GitHub) and tracks ingestion status.
+The internal `ContextSnapshot` is the normalized data model used by the backend to aggregate contextual information from multiple sources (weather, calendar, news, GitHub). 
 
-## Top-Level Schema
+The **v1 public API** returns a normalized `Context` object via `GET /api/v1/context` wrapped in the standard [response envelope](api_contract.md#response-envelope-standard).
+
+**Note:** Internal ingestion logic and error tracking (sources_ok, sources_failed) are implementation details. The v1 contract exposes only clean, aggregated fields.
+
+## Context Data Model (Public v1 API)
+
+Exposed via `GET /api/v1/context` in the `data` field of the standard response envelope.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `context_snapshot_id` | string | Unique identifier for this snapshot (UUID) |
-| `fetched_at` | string (ISO 8601, UTC) | Timestamp when data was fetched; format: `YYYY-MM-DDTHH:mm:ssZ` |
+| `context_id` | string | Unique identifier for this snapshot (e.g., `ctx_01H...`) |
+| `observed_at` | string (ISO 8601, UTC) | Timestamp when data was aggregated; format: `YYYY-MM-DDTHH:mm:ssZ` |
 | `weather` | WeatherContext \| null | Current weather conditions, or null if unavailable |
-| `calendar` | array | List of upcoming calendar events |
+| `calendar` | object | Calendar summary (e.g., `{events_today: 3}`) |
 | `news` | array | List of news articles |
 | `github` | GitHubContext \| null | GitHub repository stats, or null if unavailable |
-| `sources_ok` | array of strings | Names of sources that ingested successfully |
-| `sources_failed` | array of objects | Sources that failed; each has `{source: string, error: string}` |
 
-## Sub-Schemas
+## Internal ContextSnapshot (Backend)
+
+Used internally during ingestion; not exposed directly in v1 API.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `context_id` | string | Unique identifier for this snapshot |
+| `observed_at` | string (ISO 8601, UTC) | Timestamp when data was fetched |
+| `weather` | WeatherContext \| null | Current weather conditions |
+| `calendar` | array | List of calendar events |
+| `news` | array | List of news articles |
+| `github` | GitHubContext \| null | GitHub repository stats |
+| `sources_ok` | array of strings | **[Internal only]** Names of sources that ingested successfully |
+| `sources_failed` | array of objects | **[Internal only]** Sources that failed; each has `{source: string, error: string}` |
 
 ### WeatherContext
 
 ```json
 {
-  "temp": 72,
-  "condition": "clear"
+  "city": "Istanbul",
+  "temp_c": 8,
+  "condition": "rain"
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `temp` | number | Temperature in Celsius |
+| `city` | string | City name |
+| `temp_c` | number | Temperature in Celsius |
 | `condition` | string | One of: `rain`, `snow`, `cloudy`, `clear`, `unknown` |
 
 ### GitHubContext
 
 ```json
 {
-  "repo": "github.com/user/repo",
-  "open_issues": 5
+  "open_issues": 12,
+  "open_prs": 4
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `repo` | string | Repository identifier (e.g., `owner/repo`) |
 | `open_issues` | integer | Count of currently open issues |
+| `open_prs` | integer | Count of currently open pull requests |
 
-## Full Example
+## Full Example (Public v1 Response)
+
+Standard [response envelope](api_contract.md#response-envelope-standard) with Context in the `data` field:
 
 ```json
 {
-  "context_snapshot_id": "550e8400-e29b-41d4-a716-446655440000",
-  "fetched_at": "2026-01-21T14:30:00Z",
-  "weather": {
-    "temp": 68,
-    "condition": "cloudy"
-  },
-  "calendar": [
-    {
-      "title": "Team standup",
-      "start": "2026-01-21T09:00:00Z",
-      "end": "2026-01-21T09:30:00Z"
+  "ok": true,
+  "data": {
+    "context_id": "ctx_01H2xcejqtf2nrebnz8qp4mk78",
+    "observed_at": "2026-01-21T14:30:00Z",
+    "weather": {
+      "city": "Istanbul",
+      "temp_c": 8,
+      "condition": "rain"
     },
-    {
-      "title": "Project review",
-      "start": "2026-01-21T15:00:00Z",
-      "end": "2026-01-21T16:00:00Z"
+    "calendar": {
+      "events_today": 2
+    },
+    "news": [
+      {
+        "title": "AI breakthroughs in 2026",
+        "url": "https://example.com/news/1"
+      }
+    ],
+    "github": {
+      "open_issues": 12,
+      "open_prs": 4
     }
-  ],
-  "news": [
-    {
-      "title": "AI breakthroughs in 2026",
-      "source": "TechNews",
-      "published_at": "2026-01-21T10:00:00Z"
-    }
-  ],
-  "github": {
-    "repo": "jarvis-mission-control",
-    "open_issues": 3
   },
-  "sources_ok": ["weather", "calendar", "github"],
-  "sources_failed": [
-    {
-      "source": "news",
-      "error": "API rate limit exceeded"
-    }
-  ]
+  "meta": {
+    "request_id": "req_01H2xcejqtf2nrebnz8qp4mk78",
+    "ts": "2026-01-21T14:30:00Z"
+  }
 }
 ```
 
-## Partial Success Behavior
+## Partial Success Behavior (Internal)
 
-The `/api/v1/context/ingest` endpoint returns **HTTP 200** even if one or more sources fail to retrieve data. Failed sources are recorded in the `sources_failed` array with the source name and error message. This allows the API to accept partial context when some data sources are temporarily unavailable.
+The backend ingestion process implements partial success: if one source fails (e.g., weather API timeout), ingestion continues with other sources (e.g., GitHub, news). Failed sources are recorded in `sources_failed` (internal only) with source name and error message.
 
 - **Success criteria:** At least one source successfully ingests data.
-- **Failure response:** Returns HTTP 5xx or 4xx only if all sources fail or the request is malformed.
+- **HTTP 502 response:** Returned only if **all** sources fail or the request is malformed.
+- **HTTP 200 response:** Returned if at least one source succeeds, even with partial failures.
+
+This allows the API to always return the best available context, ensuring resilience to transient upstream failures.
+
+## References
+
+- [API Contract v1](api_contract.md) — Standard response envelope and error codes
+- [Architecture](architecture.md) — Ingestion pipeline and source connectors
+

--- a/docs/context_schema.md
+++ b/docs/context_schema.md
@@ -1,0 +1,98 @@
+# ContextSnapshot Schema
+
+## Overview
+
+The `ContextSnapshot` is the normalized data model ingested via the `/api/v1/context/ingest` endpoint. It aggregates contextual information from multiple sources (weather, calendar, news, GitHub) and tracks ingestion status.
+
+## Top-Level Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `context_snapshot_id` | string | Unique identifier for this snapshot (UUID) |
+| `fetched_at` | string (ISO 8601, UTC) | Timestamp when data was fetched; format: `YYYY-MM-DDTHH:mm:ssZ` |
+| `weather` | WeatherContext \| null | Current weather conditions, or null if unavailable |
+| `calendar` | array | List of upcoming calendar events |
+| `news` | array | List of news articles |
+| `github` | GitHubContext \| null | GitHub repository stats, or null if unavailable |
+| `sources_ok` | array of strings | Names of sources that ingested successfully |
+| `sources_failed` | array of objects | Sources that failed; each has `{source: string, error: string}` |
+
+## Sub-Schemas
+
+### WeatherContext
+
+```json
+{
+  "temp": 72,
+  "condition": "clear"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `temp` | number | Temperature in Celsius |
+| `condition` | string | One of: `rain`, `snow`, `cloudy`, `clear`, `unknown` |
+
+### GitHubContext
+
+```json
+{
+  "repo": "github.com/user/repo",
+  "open_issues": 5
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo` | string | Repository identifier (e.g., `owner/repo`) |
+| `open_issues` | integer | Count of currently open issues |
+
+## Full Example
+
+```json
+{
+  "context_snapshot_id": "550e8400-e29b-41d4-a716-446655440000",
+  "fetched_at": "2026-01-21T14:30:00Z",
+  "weather": {
+    "temp": 68,
+    "condition": "cloudy"
+  },
+  "calendar": [
+    {
+      "title": "Team standup",
+      "start": "2026-01-21T09:00:00Z",
+      "end": "2026-01-21T09:30:00Z"
+    },
+    {
+      "title": "Project review",
+      "start": "2026-01-21T15:00:00Z",
+      "end": "2026-01-21T16:00:00Z"
+    }
+  ],
+  "news": [
+    {
+      "title": "AI breakthroughs in 2026",
+      "source": "TechNews",
+      "published_at": "2026-01-21T10:00:00Z"
+    }
+  ],
+  "github": {
+    "repo": "jarvis-mission-control",
+    "open_issues": 3
+  },
+  "sources_ok": ["weather", "calendar", "github"],
+  "sources_failed": [
+    {
+      "source": "news",
+      "error": "API rate limit exceeded"
+    }
+  ]
+}
+```
+
+## Partial Success Behavior
+
+The `/api/v1/context/ingest` endpoint returns **HTTP 200** even if one or more sources fail to retrieve data. Failed sources are recorded in the `sources_failed` array with the source name and error message. This allows the API to accept partial context when some data sources are temporarily unavailable.
+
+- **Success criteria:** At least one source successfully ingests data.
+- **Failure response:** Returns HTTP 5xx or 4xx only if all sources fail or the request is malformed.


### PR DESCRIPTION
## Summary This PR adds the normalized ContextSnapshot schema used by the ingestion pipeline.
It defines a stable contract for weather, calendar, news, and GitHub context sources,
including partial-success behavior.


## Screenshots (if UI)

## How to test
- Open `docs/context_schema.md`
- Verify the JSON example and field definitions
- Confirm partial success behavior is documented

- Command(s):
- Expected output:

## Checklist
- [x] Issue linked
- [x] Clear description
- [x] Tests run (commands listed above)
- [x] Breaking change noted (if any)
