### PR TITLE
P1: request tracing (X-Request-Id) + structured logs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import logging
+import time
 import uuid
 
 from fastapi import FastAPI, Request
@@ -18,42 +21,68 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="jarvis-mission-control", version=settings.app_version)
 
+    logger = logging.getLogger("jarvis")
+
     @app.middleware("http")
     async def request_id_middleware(request: Request, call_next):
-        request.state.request_id = f"req_{uuid.uuid4().hex}"
-        response = await call_next(request)
+        start = time.perf_counter()
+
+        incoming_request_id = request.headers.get("X-Request-Id")
+        request_id = incoming_request_id.strip() if incoming_request_id else ""
+        if not request_id:
+            request_id = f"req_{uuid.uuid4().hex}"
+
+        request.state.request_id = request_id
+
+        try:
+            response = await call_next(request)
+        except RequestValidationError as exc:
+            payload, status = err(
+                request,
+                code="INVALID_PARAMS",
+                message="Invalid request parameters",
+                status_code=400,
+                details={"errors": exc.errors()},
+            )
+            response = JSONResponse(payload, status_code=status)
+        except HTTPException as exc:
+            payload, status = err(
+                request,
+                code="HTTP_ERROR",
+                message=str(exc.detail),
+                status_code=exc.status_code,
+            )
+            response = JSONResponse(payload, status_code=status)
+        except Exception:
+            payload, status = err(
+                request,
+                code="INTERNAL",
+                message="Unexpected server error",
+                status_code=500,
+            )
+            response = JSONResponse(payload, status_code=status)
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        response.headers["X-Request-Id"] = request_id
+
+        logger.info(
+            json.dumps(
+                {
+                    "event": "request",
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status": getattr(response, "status_code", None),
+                    "duration_ms": duration_ms,
+                }
+            )
+        )
+
         return response
 
-    @app.exception_handler(RequestValidationError)
-    async def validation_exception_handler(request: Request, exc: RequestValidationError):
-        payload, status = err(
-            request,
-            code="INVALID_PARAMS",
-            message="Invalid request parameters",
-            status_code=400,
-            details={"errors": exc.errors()},
-        )
-        return JSONResponse(payload, status_code=status)
-
-    @app.exception_handler(HTTPException)
-    async def http_exception_handler(request: Request, exc: HTTPException):
-        payload, status = err(
-            request,
-            code="HTTP_ERROR",
-            message=str(exc.detail),
-            status_code=exc.status_code,
-        )
-        return JSONResponse(payload, status_code=status)
-
-    @app.exception_handler(Exception)
-    async def unhandled_exception_handler(request: Request, exc: Exception):
-        payload, status = err(
-            request,
-            code="INTERNAL",
-            message="Unexpected server error",
-            status_code=500,
-        )
-        return JSONResponse(payload, status_code=status)
+    # NOTE: We intentionally handle exceptions in middleware so that:
+    # - every response includes X-Request-Id
+    # - error responses keep the standard envelope
 
     @app.on_event("startup")
     async def _startup():

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -15,8 +15,24 @@ def test_health_200_and_version_present():
         res = client.get("/api/v1/health")
         assert res.status_code == 200
 
+        request_id = res.headers.get("X-Request-Id")
+        assert isinstance(request_id, str)
+        assert request_id
+
         body = res.json()
         assert body["ok"] is True
         assert body["data"]["service"] == "backend"
         assert isinstance(body["data"]["version"], str)
         assert body["data"]["version"]
+        assert body["meta"]["request_id"] == request_id
+
+
+def test_health_echoes_client_request_id():
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    app = create_app()
+
+    with TestClient(app) as client:
+        res = client.get("/api/v1/health", headers={"X-Request-Id": "req_test_123"})
+        assert res.status_code == 200
+        assert res.headers.get("X-Request-Id") == "req_test_123"
+        assert res.json()["meta"]["request_id"] == "req_test_123"

--- a/infra/scripts/demo.sh
+++ b/infra/scripts/demo.sh
@@ -7,6 +7,11 @@ echo "== Health =="
 curl -is "$API_BASE_URL/api/v1/health" | sed -n '1,25p'
 
 echo
+echo "== Request ID example (from /health) =="
+curl -is "$API_BASE_URL/api/v1/health" \
+	| awk 'BEGIN{IGNORECASE=1} /^x-request-id:/{gsub("\r","",$0); print; exit}'
+
+echo
 echo "== Synthetic (MISS) n=100000 seed=42 =="
 curl -is "$API_BASE_URL/api/v1/synthetic/tasks?n=100000&seed=42" \
 	| awk 'BEGIN{IGNORECASE=1} /^x-cache:|^x-cache-key:|^x-compute-time-ms:/{print} /^\{/{print; exit}'


### PR DESCRIPTION
Implements #27.

What changed
- Adds/echoes X-Request-Id on every response
- Adds structured request logs with: request_id, path, status, duration_ms
- Updates infra/scripts/demo.sh to print one request-id example
- Adds pytest assertions for header presence + echo behavior

How to test
- docker compose run --rm backend pytest -q
- infra/scripts/demo.sh (look for the X-Request-Id: line)