### PR TITLE
P1: harden CORS + baseline security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Backend environment variables:
 - `APP_VERSION` (default: `0.1.0`)
 - `REDIS_URL` (default: `redis://redis:6379/0` for Compose)
 - `CACHE_TTL_SECONDS` (default: `120`)
+- `CORS_ALLOWED_ORIGINS` (default: `http://localhost:3000,http://127.0.0.1:3000`)
+- `CORS_ALLOW_CREDENTIALS` (default: `false`)
+
+Backend also sets baseline security headers on responses:
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: no-referrer`
+- `Permissions-Policy: geolocation=(), microphone=(), camera=()`
 
 Example file: `backend/.env.example`
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ import uuid
 
 from fastapi import FastAPI, Request
 from fastapi import HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
@@ -20,6 +21,15 @@ def create_app() -> FastAPI:
     settings = get_settings()
 
     app = FastAPI(title="jarvis-mission-control", version=settings.app_version)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(settings.cors_allowed_origins),
+        allow_credentials=settings.cors_allow_credentials,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["*"],
+        expose_headers=["X-Request-Id", "X-Cache", "X-Cache-Key", "X-Compute-Time-ms"],
+    )
 
     logger = logging.getLogger("jarvis")
 
@@ -64,6 +74,15 @@ def create_app() -> FastAPI:
 
         duration_ms = int((time.perf_counter() - start) * 1000)
         response.headers["X-Request-Id"] = request_id
+
+        # Basic security headers (baseline)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        response.headers.setdefault(
+            "Permissions-Policy",
+            "geolocation=(), microphone=(), camera=()",
+        )
 
         logger.info(
             json.dumps(

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -9,6 +9,17 @@ class Settings:
     app_version: str
     redis_url: str
     cache_ttl_seconds: int
+    cors_allowed_origins: tuple[str, ...]
+    cors_allow_credentials: bool
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_csv(value: str) -> tuple[str, ...]:
+    items = [item.strip() for item in value.split(",")]
+    return tuple([item for item in items if item])
 
 
 def get_settings() -> Settings:
@@ -16,4 +27,8 @@ def get_settings() -> Settings:
         app_version=os.getenv("APP_VERSION", "0.1.0"),
         redis_url=os.getenv("REDIS_URL", "redis://redis:6379/0"),
         cache_ttl_seconds=int(os.getenv("CACHE_TTL_SECONDS", "120")),
+        cors_allowed_origins=_parse_csv(
+            os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000")
+        ),
+        cors_allow_credentials=_parse_bool(os.getenv("CORS_ALLOW_CREDENTIALS", "false")),
     )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -26,6 +26,12 @@ def test_health_200_and_version_present():
         assert body["data"]["version"]
         assert body["meta"]["request_id"] == request_id
 
+        assert res.headers.get("X-Content-Type-Options") == "nosniff"
+        assert res.headers.get("X-Frame-Options") == "DENY"
+        assert res.headers.get("Referrer-Policy") == "no-referrer"
+        assert isinstance(res.headers.get("Permissions-Policy"), str)
+        assert res.headers.get("Permissions-Policy")
+
 
 def test_health_echoes_client_request_id():
     os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
@@ -36,3 +42,20 @@ def test_health_echoes_client_request_id():
         assert res.status_code == 200
         assert res.headers.get("X-Request-Id") == "req_test_123"
         assert res.json()["meta"]["request_id"] == "req_test_123"
+
+
+def test_cors_preflight_allows_local_frontend_origin():
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    # Allow default origins from settings (includes http://localhost:3000)
+    app = create_app()
+
+    with TestClient(app) as client:
+        res = client.options(
+            "/api/v1/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert res.status_code in {200, 204}
+        assert res.headers.get("access-control-allow-origin") == "http://localhost:3000"


### PR DESCRIPTION
Implements #29.

What changed
- Configurable CORS allowlist (defaults to localhost:3000 + 127.0.0.1:3000)
- Adds baseline security headers on all responses
- Adds tests for headers + CORS preflight
- Documents env vars + headers in README

How to test
- docker compose run --rm backend pytest -q
- docker compose up -d --build && curl -is http://localhost:8000/api/v1/health | sed -n '1,30p'