### PR TITLE
P1: /metrics + cache hit/miss counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ You can also point the script to another base URL:
 API_BASE_URL="http://localhost:8000" bash infra/scripts/demo.sh
 ```
 
+## Metrics (Prometheus)
+The backend exposes `GET /metrics` in Prometheus text format.
+
+```bash
+curl -s http://localhost:8000/metrics | head
+curl -s http://localhost:8000/metrics | grep -E 'cache_hits_total|cache_misses_total'
+```
+
 ## API quick reference
 All endpoints are under `/api/v1` and use the same response envelope.
 

--- a/backend/app/api/v1/endpoints/synthetic.py
+++ b/backend/app/api/v1/endpoints/synthetic.py
@@ -12,6 +12,7 @@ from redis.asyncio import Redis
 
 from app.cache import cache_key_synthetic_tasks, get_json, set_json
 from app.http_envelope import err, ok
+from app.metrics import inc_cache_hit, inc_cache_miss, inc_synthetic_generated
 from app.settings import get_settings
 
 router = APIRouter()
@@ -74,6 +75,7 @@ async def synthetic_tasks(
         cached = await get_json(redis, cache_key)
 
     if cached is not None:
+        inc_cache_hit()
         data = cached["data"]
         response = JSONResponse(
             ok(request, data, extra_meta={"total": n}),
@@ -83,6 +85,8 @@ async def synthetic_tasks(
         response.headers["X-Cache-Key"] = cache_key
         response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
     else:
+        inc_cache_miss()
+        inc_synthetic_generated(n)
         sample = _make_sample(n=n, seed=used_seed, sample_size=sample_size)
         data = {
             "n": n,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,11 +9,14 @@ from fastapi import FastAPI, Request
 from fastapi import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
+from fastapi.responses import Response
 from fastapi.responses import JSONResponse
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from redis.asyncio import Redis
 
 from app.api.v1.router import api_router
 from app.http_envelope import err
+from app.metrics import observe_request
 from app.settings import get_settings
 
 
@@ -72,7 +75,8 @@ def create_app() -> FastAPI:
             )
             response = JSONResponse(payload, status_code=status)
 
-        duration_ms = int((time.perf_counter() - start) * 1000)
+        duration_s = time.perf_counter() - start
+        duration_ms = int(duration_s * 1000)
         response.headers["X-Request-Id"] = request_id
 
         # Basic security headers (baseline)
@@ -97,7 +101,18 @@ def create_app() -> FastAPI:
             )
         )
 
+        observe_request(
+            method=request.method,
+            path=request.url.path,
+            status=int(getattr(response, "status_code", 0) or 0),
+            duration_seconds=duration_s,
+        )
+
         return response
+
+    @app.get("/metrics")
+    async def metrics() -> Response:
+        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
     # NOTE: We intentionally handle exceptions in middleware so that:
     # - every response includes X-Request-Id

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total number of HTTP requests.",
+    ["method", "path", "status"],
+)
+
+http_request_duration_seconds = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds.",
+    ["method", "path"],
+)
+
+cache_hits_total = Counter(
+    "cache_hits_total",
+    "Total cache hits.",
+)
+
+cache_misses_total = Counter(
+    "cache_misses_total",
+    "Total cache misses.",
+)
+
+synthetic_tasks_generated_total = Counter(
+    "synthetic_tasks_generated_total",
+    "Total synthetic tasks requested/generated (by n parameter).",
+)
+
+
+def observe_request(*, method: str, path: str, status: int, duration_seconds: float) -> None:
+    http_requests_total.labels(method=method, path=path, status=str(status)).inc()
+    http_request_duration_seconds.labels(method=method, path=path).observe(duration_seconds)
+
+
+def inc_cache_hit() -> None:
+    cache_hits_total.inc()
+
+
+def inc_cache_miss() -> None:
+    cache_misses_total.inc()
+
+
+def inc_synthetic_generated(n: int) -> None:
+    if n > 0:
+        synthetic_tasks_generated_total.inc(n)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ redis==5.0.1
 pydantic==2.6.4
 pytest==8.3.4
 httpx==0.27.2
+prometheus-client==0.20.0

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+import re
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def _get_counter_value(metrics_text: str, name: str) -> float:
+    # Matches lines like:
+    # cache_hits_total 3
+    pattern = re.compile(rf"^{re.escape(name)}\s+([0-9]+(?:\.[0-9]+)?)$", re.MULTILINE)
+    match = pattern.search(metrics_text)
+    if not match:
+        raise AssertionError(f"Counter '{name}' not found in /metrics output")
+    return float(match.group(1))
+
+
+def test_metrics_endpoint_exposes_expected_metric_names():
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    app = create_app()
+
+    with TestClient(app) as client:
+        res = client.get("/metrics")
+        assert res.status_code == 200
+        assert res.headers["content-type"].startswith("text/plain")
+
+        body = res.text
+        assert "http_requests_total" in body
+        assert "http_request_duration_seconds" in body
+        assert "cache_hits_total" in body
+        assert "cache_misses_total" in body
+        assert "synthetic_tasks_generated_total" in body
+
+
+def test_cache_hit_miss_counters_increase_with_synthetic_calls():
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    app = create_app()
+
+    with TestClient(app) as client:
+        before = client.get("/metrics").text
+        hits_before = _get_counter_value(before, "cache_hits_total")
+        misses_before = _get_counter_value(before, "cache_misses_total")
+
+        # First call should MISS, second should HIT (seed enables caching)
+        r1 = client.get("/api/v1/synthetic/tasks?n=100000&seed=42")
+        assert r1.status_code == 200
+        r2 = client.get("/api/v1/synthetic/tasks?n=100000&seed=42")
+        assert r2.status_code == 200
+
+        after = client.get("/metrics").text
+        hits_after = _get_counter_value(after, "cache_hits_total")
+        misses_after = _get_counter_value(after, "cache_misses_total")
+
+        assert misses_after >= misses_before + 1
+        assert hits_after >= hits_before + 1

--- a/infra/scripts/demo.sh
+++ b/infra/scripts/demo.sh
@@ -123,3 +123,14 @@ echo
 echo "== Report (missions preview) =="
 curl -s "$API_BASE_URL/api/v1/report?window=30d&bucket=hour" \
 	| sed -n '1,200p'
+
+echo
+echo "== Metrics snapshot (after demo) =="
+if curl -fsS "$API_BASE_URL/metrics" >/dev/null 2>&1; then
+	curl -s "$API_BASE_URL/metrics" \
+		| grep -E '^(cache_hits_total|cache_misses_total|synthetic_tasks_generated_total)\b' \
+		| sed -n '1,10p'
+	_pass "/metrics reachable"
+else
+	_fail "/metrics not reachable"
+fi


### PR DESCRIPTION
Implements #26.

What changed
- Adds GET /metrics (Prometheus text format)
- Metrics:
  - http_requests_total{method,path,status}
  - http_request_duration_seconds{method,path}
  - cache_hits_total / cache_misses_total
  - synthetic_tasks_generated_total
- Cache hit/miss counters increment from /api/v1/synthetic/tasks
- demo.sh prints a small metrics snapshot after the cache proof
- Adds pytest coverage for /metrics and hit/miss increments
- README: how to curl /metrics

How to verify quickly
- docker compose up -d --build
- curl -s http://localhost:8000/metrics | head
- bash infra/scripts/demo.sh (check cache_hits_total / cache_misses_total lines)