### PR TITLE
P1: rate limit /synthetic/tasks (429 envelope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Deploy target: Docker Compose behind Nginx + optional SSL.
 	- Caching is **enabled only when `seed` is provided**.
 	- Payload stays small: returns `sample` + `preview_hash` + `meta.total` (not 100k/1M items).
 	- Cache proof headers: `X-Cache`, `X-Compute-Time-ms` (and `X-Cache-Key` as extra proof).
+	- Rate limited (returns 429 with standard error envelope + `Retry-After`).
 - `GET /api/v1/report` exists as a demo-friendly placeholder (not cached in sprint 1).
 
 ## Team workflow rules
@@ -103,8 +104,25 @@ Backend environment variables:
 - `APP_VERSION` (default: `0.1.0`)
 - `REDIS_URL` (default: `redis://redis:6379/0` for Compose)
 - `CACHE_TTL_SECONDS` (default: `120`)
+- `SYNTHETIC_RATELIMIT_PER_MIN` (default: `30`)
+- `SYNTHETIC_RATELIMIT_WINDOW_SECONDS` (default: `60`)
 - `CORS_ALLOWED_ORIGINS` (default: `http://localhost:3000,http://127.0.0.1:3000`)
 - `CORS_ALLOW_CREDENTIALS` (default: `false`)
+
+Quick check (rate limit):
+
+```bash
+export SYNTHETIC_RATELIMIT_PER_MIN=2
+export SYNTHETIC_RATELIMIT_WINDOW_SECONDS=60
+
+for i in 1 2 3; do
+	echo "--- $i"
+	curl -s -D - -o /dev/null \
+		-H 'X-Forwarded-For: 1.2.3.4' \
+		'http://localhost:8000/api/v1/synthetic/tasks?n=100000&seed=42' \
+		| awk 'NR==1{print "status=" $2} /^Retry-After:/{gsub("\r","",$2); print "retry_after=" $2}'
+done
+```
 
 Backend also sets baseline security headers on responses:
 - `X-Content-Type-Options: nosniff`

--- a/backend/app/api/v1/endpoints/synthetic.py
+++ b/backend/app/api/v1/endpoints/synthetic.py
@@ -13,6 +13,7 @@ from redis.asyncio import Redis
 from app.cache import cache_key_synthetic_tasks, get_json, set_json
 from app.http_envelope import err, ok
 from app.metrics import inc_cache_hit, inc_cache_miss, inc_synthetic_generated
+from app.rate_limit import fixed_window_allow, synthetic_client_id, synthetic_rate_limit_key
 from app.settings import get_settings
 
 router = APIRouter()
@@ -62,6 +63,33 @@ async def synthetic_tasks(
 
     settings = get_settings()
     redis: Redis = request.app.state.redis
+
+    limit = settings.synthetic_ratelimit_per_min
+    window_seconds = settings.synthetic_ratelimit_window_seconds
+    if limit > 0 and window_seconds > 0:
+        client_id = synthetic_client_id(
+            x_forwarded_for=request.headers.get("X-Forwarded-For"),
+            client_host=getattr(request.client, "host", None),
+            x_api_key=request.headers.get("X-Api-Key"),
+        )
+        rate_key = synthetic_rate_limit_key(client_id=client_id, window_seconds=window_seconds)
+        allowed, _count, retry_after = await fixed_window_allow(
+            redis=redis,
+            key=rate_key,
+            limit=limit,
+            window_seconds=window_seconds,
+        )
+        if not allowed:
+            payload, status = err(
+                request,
+                code="rate_limited",
+                message="Too many requests",
+                status_code=429,
+                details={"limit": limit, "window_seconds": window_seconds},
+            )
+            response = JSONResponse(payload, status_code=status)
+            response.headers["Retry-After"] = str(retry_after)
+            return response
 
     sample_size = 50
     cache_enabled = seed is not None

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from redis.asyncio import Redis
+
+
+_LOCAL_COUNTERS: dict[str, tuple[int, int]] = {}
+# value: (count, expires_at_unix)
+
+
+def _now_unix() -> int:
+    return int(time.time())
+
+
+def _window_id(now_unix: int, window_seconds: int) -> int:
+    return now_unix // window_seconds
+
+
+def _window_reset_in(now_unix: int, window_seconds: int) -> int:
+    wid = _window_id(now_unix, window_seconds)
+    reset_at = (wid + 1) * window_seconds
+    return max(1, reset_at - now_unix)
+
+
+def synthetic_client_id(*, x_forwarded_for: Optional[str], client_host: Optional[str], x_api_key: Optional[str]) -> str:
+    if x_api_key:
+        return f"key:{x_api_key.strip()}"
+
+    ip = ""
+    if x_forwarded_for:
+        # X-Forwarded-For: client, proxy1, proxy2
+        ip = x_forwarded_for.split(",", 1)[0].strip()
+
+    if not ip:
+        ip = (client_host or "unknown").strip()
+
+    return f"ip:{ip}"
+
+
+def synthetic_rate_limit_key(*, client_id: str, window_seconds: int, now_unix: Optional[int] = None) -> str:
+    now = _now_unix() if now_unix is None else int(now_unix)
+    wid = _window_id(now, window_seconds)
+    return f"ratelimit:synthetic:{client_id}:{wid}"
+
+
+async def fixed_window_allow(
+    *,
+    redis: Optional[Redis],
+    key: str,
+    limit: int,
+    window_seconds: int,
+    now_unix: Optional[int] = None,
+) -> tuple[bool, int, int]:
+    """Returns (allowed, count, retry_after_seconds).
+
+    Uses Redis if available, otherwise falls back to an in-memory counter.
+    """
+
+    now = _now_unix() if now_unix is None else int(now_unix)
+
+    if limit <= 0:
+        return True, 0, 0
+
+    if window_seconds <= 0:
+        # Defensive: treat invalid window as "no rate limit"
+        return True, 0, 0
+
+    if redis is not None:
+        try:
+            count = int(await redis.incr(key))
+            if count == 1:
+                await redis.expire(key, window_seconds)
+
+            if count <= limit:
+                return True, count, 0
+
+            return False, count, _window_reset_in(now, window_seconds)
+        except Exception:
+            # Fall back to in-memory below
+            pass
+
+    expires_at = now + window_seconds
+
+    stored = _LOCAL_COUNTERS.get(key)
+    if stored is None:
+        count = 1
+        _LOCAL_COUNTERS[key] = (count, expires_at)
+    else:
+        prev_count, prev_expires_at = stored
+        if prev_expires_at <= now:
+            count = 1
+            _LOCAL_COUNTERS[key] = (count, expires_at)
+        else:
+            count = prev_count + 1
+            _LOCAL_COUNTERS[key] = (count, prev_expires_at)
+
+    if count <= limit:
+        return True, count, 0
+
+    return False, count, _window_reset_in(now, window_seconds)

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -9,6 +9,8 @@ class Settings:
     app_version: str
     redis_url: str
     cache_ttl_seconds: int
+    synthetic_ratelimit_per_min: int
+    synthetic_ratelimit_window_seconds: int
     cors_allowed_origins: tuple[str, ...]
     cors_allow_credentials: bool
 
@@ -27,6 +29,8 @@ def get_settings() -> Settings:
         app_version=os.getenv("APP_VERSION", "0.1.0"),
         redis_url=os.getenv("REDIS_URL", "redis://redis:6379/0"),
         cache_ttl_seconds=int(os.getenv("CACHE_TTL_SECONDS", "120")),
+        synthetic_ratelimit_per_min=int(os.getenv("SYNTHETIC_RATELIMIT_PER_MIN", "30")),
+        synthetic_ratelimit_window_seconds=int(os.getenv("SYNTHETIC_RATELIMIT_WINDOW_SECONDS", "60")),
         cors_allowed_origins=_parse_csv(
             os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000")
         ),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,3 +27,21 @@ def redis_client(redis_url: str) -> Redis:
     except Exception as exc:
         pytest.skip(f"Redis not available at {redis_url}: {exc}")
     return client
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limit_keys(redis_url: str):
+    """Keep tests deterministic by clearing Redis-backed rate-limit counters.
+
+    This is best-effort and should not cause skips/failures if Redis is absent.
+    """
+
+    client = Redis.from_url(redis_url, decode_responses=True)
+    try:
+        client.ping()
+    except Exception:
+        return
+
+    keys = client.keys("ratelimit:synthetic:*")
+    if keys:
+        client.delete(*keys)

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -5,6 +5,7 @@ import re
 
 from fastapi.testclient import TestClient
 
+from app.cache import cache_key_synthetic_tasks
 from app.main import create_app
 
 
@@ -35,9 +36,14 @@ def test_metrics_endpoint_exposes_expected_metric_names():
         assert "synthetic_tasks_generated_total" in body
 
 
-def test_cache_hit_miss_counters_increase_with_synthetic_calls():
+def test_cache_hit_miss_counters_increase_with_synthetic_calls(redis_client):
     os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
     app = create_app()
+
+    n = 100000
+    seed = 42
+    cache_key = cache_key_synthetic_tasks(n=n, seed=seed, sample_size=50)
+    redis_client.delete(cache_key)
 
     with TestClient(app) as client:
         before = client.get("/metrics").text
@@ -45,9 +51,9 @@ def test_cache_hit_miss_counters_increase_with_synthetic_calls():
         misses_before = _get_counter_value(before, "cache_misses_total")
 
         # First call should MISS, second should HIT (seed enables caching)
-        r1 = client.get("/api/v1/synthetic/tasks?n=100000&seed=42")
+        r1 = client.get(f"/api/v1/synthetic/tasks?n={n}&seed={seed}")
         assert r1.status_code == 200
-        r2 = client.get("/api/v1/synthetic/tasks?n=100000&seed=42")
+        r2 = client.get(f"/api/v1/synthetic/tasks?n={n}&seed={seed}")
         assert r2.status_code == 200
 
         after = client.get("/metrics").text

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import time
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_synthetic_tasks_rate_limited(redis_client, monkeypatch):
+    # Deterministic + non-flaky: long window so we don't cross boundary.
+    monkeypatch.setenv("REDIS_URL", os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+    monkeypatch.setenv("SYNTHETIC_RATELIMIT_PER_MIN", "2")
+    monkeypatch.setenv("SYNTHETIC_RATELIMIT_WINDOW_SECONDS", "3600")
+
+    client_ip = "1.2.3.4"
+    client_id = f"ip:{client_ip}"
+    window_seconds = 3600
+    window_id = int(time.time()) // window_seconds
+    redis_client.delete(f"ratelimit:synthetic:{client_id}:{window_id}")
+
+    app = create_app()
+
+    headers = {"X-Forwarded-For": client_ip}
+    params = {"n": 100000, "seed": 42}
+
+    with TestClient(app) as client:
+        r1 = client.get("/api/v1/synthetic/tasks", params=params, headers=headers)
+        assert r1.status_code == 200
+
+        r2 = client.get("/api/v1/synthetic/tasks", params=params, headers=headers)
+        assert r2.status_code == 200
+
+        r3 = client.get("/api/v1/synthetic/tasks", params=params, headers=headers)
+        assert r3.status_code == 429
+        assert r3.headers.get("X-Request-Id")
+        assert r3.headers.get("Retry-After")
+
+        body = r3.json()
+        assert body["ok"] is False
+        assert body["error"]["code"] == "rate_limited"
+        assert body["error"]["details"]["limit"] == 2
+        assert body["error"]["details"]["window_seconds"] == 3600
+        assert body["meta"]["request_id"] == r3.headers["X-Request-Id"]


### PR DESCRIPTION
Implements issue #28: rate limit only /api/v1/synthetic/tasks.

What changed
- Redis fixed-window counter with TTL (in-memory fallback)
- 429 standard error envelope with details + Retry-After
- Tests: deterministic 200,200,429 for same client
- README: env vars + quick curl loop

How to verify
- Set: SYNTHETIC_RATELIMIT_PER_MIN=2 and SYNTHETIC_RATELIMIT_WINDOW_SECONDS=60
- Call /api/v1/synthetic/tasks 3x with same X-Forwarded-For
  - 1-2 => 200
  - 3 => 429 with error.code=rate_limited and Retry-After header
