### PR TITLE
ingestion: add news adapter (hackernews) with normalized mapping

### DIFF
--- a/backend/app/api/v1/endpoints/context.py
+++ b/backend/app/api/v1/endpoints/context.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 from app.http_envelope import ok, err
 from app.services.ingestion.weather import fetch_weather
 from app.services.ingestion.github import fetch_github
+from app.services.ingestion.news import fetch_news
 
 router = APIRouter()
 
@@ -22,9 +23,9 @@ async def get_context(request: Request):
     """
     fetched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
-    data: dict = {"fetched_at": fetched_at, "weather": None, "github": None}
-    sources_ok: list[str] = []
-    sources_failed: list[dict[str, str]] = []
+    data: dict = {"fetched_at": fetched_at, "weather": None, "github": None, "news": []}
+    sources_ok = []
+    sources_failed = []
 
     # Weather
     try:
@@ -34,7 +35,6 @@ async def get_context(request: Request):
             "lat": os.getenv("WEATHER_LAT"),
             "lon": os.getenv("WEATHER_LON"),
             "tz": os.getenv("WEATHER_TZ"),
-            # normalize common keys from ingestion
             "temp_c": w.get("temp") if isinstance(w, dict) else None,
             "condition": w.get("condition") if isinstance(w, dict) else None,
             "raw": w if isinstance(w, dict) else {"value": w},
@@ -57,11 +57,24 @@ async def get_context(request: Request):
     except Exception as e:
         sources_failed.append({"source": "github", "error": str(e)})
 
+    # News
+    try:
+        news_items = await fetch_news(limit=5)
+        data["news"] = news_items
+        sources_ok.append("news")
+    except Exception as e:
+        sources_failed.append({"source": "news", "error": str(e)})
+
     data["sources_ok"] = sources_ok
     data["sources_failed"] = sources_failed
 
     if len(sources_ok) == 0:
-        payload = err(request, code="BAD_GATEWAY", message="All context sources failed", details={"sources_failed": sources_failed})
+        payload = err(
+            request,
+            code="BAD_GATEWAY",
+            message="All context sources failed",
+            details={"sources_failed": sources_failed},
+        )
         return JSONResponse(payload, status_code=502)
 
     payload = ok(request, data)

--- a/backend/app/services/ingestion/news.py
+++ b/backend/app/services/ingestion/news.py
@@ -1,0 +1,56 @@
+import logging
+import httpx
+from typing import List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# Hacker News search API (Algolia) - no API key required
+HN_SEARCH_URL = "https://hn.algolia.com/api/v1/search"
+
+
+async def fetch_news(limit: int = 5) -> List[Dict[str, str]]:
+    """
+    Fetch news items from a single external source and map to normalized schema.
+
+    Normalized output:
+      [{"title": "<str>", "url": "<str>"}]
+
+    Behavior:
+    - On error, raise Exception (caller will handle partial failure)
+    """
+    params = {
+        "tags": "front_page",  # stable, always returns top stories
+        "hitsPerPage": max(1, min(int(limit), 20)),
+    }
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(HN_SEARCH_URL, params=params)
+
+    if resp.status_code != 200:
+        raise Exception(f"HN API returned {resp.status_code}: {resp.text}")
+
+    data: Dict[str, Any] = resp.json()
+    hits = data.get("hits", [])
+    if not isinstance(hits, list):
+        raise Exception("HN API response missing 'hits' list")
+
+    items: List[Dict[str, str]] = []
+
+    for h in hits:
+        # title can be in different fields depending on record
+        title = (h.get("title") or h.get("story_title") or "").strip()
+
+        # Prefer the external URL; fallback to HN item URL if missing
+        url = (h.get("url") or "").strip()
+        if not url:
+            object_id = h.get("objectID")
+            if object_id:
+                url = f"https://news.ycombinator.com/item?id={object_id}"
+
+        # Skip empty rows
+        if not title or not url:
+            continue
+
+        items.append({"title": title, "url": url})
+
+    return items


### PR DESCRIPTION
## Summary
Implements a news ingestion adapter using a single external source (Hacker News via Algolia API) and maps results into the normalized context schema.

## Issue link
- Closes #19

## Evidence
- `GET /api/v1/context` returns `news` as a list of `{title, url}` items and records partial failures in `sources_failed`.

## How to test
- Run backend: `uvicorn app.main:app --reload`
- Call: `GET http://127.0.0.1:8000/api/v1/context`
- Verify `data.news` is populated; if upstream fails, `news` should be `[]` and request still succeeds if any other source succeeds.
