### PR TITLE
P1: Missions engine + mission-load report (cache proof)

### DIFF
--- a/backend/app/api/v1/endpoints/context.py
+++ b/backend/app/api/v1/endpoints/context.py
@@ -1,19 +1,15 @@
 ﻿from __future__ import annotations
 
-import os
-from datetime import datetime, timezone
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
-from app.http_envelope import ok, err
-from app.services.ingestion.weather import fetch_weather
-from app.services.ingestion.github import fetch_github
-from app.services.ingestion.news import fetch_news
+from app.http_envelope import err, ok
+from app.services.context import build_context_snapshot
 
 router = APIRouter()
 
 @router.get("/context")
-async def get_context(request: Request):
+async def get_context(request: Request, debug: bool = Query(False)):
     """
     Return latest aggregated context snapshot.
 
@@ -21,61 +17,19 @@ async def get_context(request: Request):
       - If one source fails but another succeeds -> 200 with failed list.
       - If all sources fail -> 502.
     """
-    fetched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    data = await build_context_snapshot(debug=debug)
 
-    data: dict = {"fetched_at": fetched_at, "weather": None, "github": None, "news": []}
-    sources_ok = []
-    sources_failed = []
-
-    # Weather
-    try:
-        w = await fetch_weather()
-        data["weather"] = {
-            "city": os.getenv("WEATHER_CITY", "Unknown"),
-            "lat": os.getenv("WEATHER_LAT"),
-            "lon": os.getenv("WEATHER_LON"),
-            "tz": os.getenv("WEATHER_TZ"),
-            "temp_c": w.get("temp") if isinstance(w, dict) else None,
-            "condition": w.get("condition") if isinstance(w, dict) else None,
-            "raw": w if isinstance(w, dict) else {"value": w},
-        }
-        sources_ok.append("weather")
-    except Exception as e:
-        sources_failed.append({"source": "weather", "error": str(e)})
-
-    # GitHub
-    try:
-        g = await fetch_github()
-        data["github"] = {
-            "owner": os.getenv("GITHUB_OWNER"),
-            "repo": os.getenv("GITHUB_REPO"),
-            "open_issues": g.get("open_issues") if isinstance(g, dict) else None,
-            "open_prs": g.get("open_prs") if isinstance(g, dict) else None,
-            "raw": g if isinstance(g, dict) else {"value": g},
-        }
-        sources_ok.append("github")
-    except Exception as e:
-        sources_failed.append({"source": "github", "error": str(e)})
-
-    # News
-    try:
-        news_items = await fetch_news(limit=5)
-        data["news"] = news_items
-        sources_ok.append("news")
-    except Exception as e:
-        sources_failed.append({"source": "news", "error": str(e)})
-
-    data["sources_ok"] = sources_ok
-    data["sources_failed"] = sources_failed
-
-    if len(sources_ok) == 0:
-        payload = err(
+    if len(data.get("sources_ok") or []) == 0:
+        payload, status = err(
             request,
-            code="BAD_GATEWAY",
+            code="UPSTREAM_FAILED",
             message="All context sources failed",
-            details={"sources_failed": sources_failed},
+            status_code=502,
+            details={
+                "sources_failed": data.get("sources_failed"),
+                "sources_skipped": data.get("sources_skipped"),
+            },
         )
-        return JSONResponse(payload, status_code=502)
+        return JSONResponse(payload, status_code=status)
 
-    payload = ok(request, data)
-    return JSONResponse(payload, status_code=200)
+    return JSONResponse(ok(request, data), status_code=200)

--- a/backend/app/api/v1/endpoints/missions.py
+++ b/backend/app/api/v1/endpoints/missions.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Literal, Optional
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from app.http_envelope import ok
+from app.services.context import build_context_snapshot
+from app.services.missions import generate_missions
+
+router = APIRouter()
+
+
+class Preferences(BaseModel):
+    energy_level: Optional[Literal["low", "medium", "high"]] = None
+    time_of_day: Optional[Literal["morning", "afternoon", "evening"]] = None
+
+
+class MissionsGenerateRequest(BaseModel):
+    context: Optional[dict[str, Any]] = None
+    preferences: Optional[Preferences] = None
+    limit: int = Field(15, ge=1, le=30)
+    seed: Optional[int] = None
+
+
+@router.post("/missions/generate")
+async def missions_generate(request: Request, body: MissionsGenerateRequest):
+    start = time.perf_counter()
+
+    context = body.context
+    if context is None:
+        context = await build_context_snapshot(debug=False)
+
+    missions = generate_missions(
+        context=context,
+        preferences=body.preferences.model_dump() if body.preferences else None,
+        limit=body.limit,
+        seed=body.seed,
+    )
+
+    data = {
+        "context": {
+            "context_id": context.get("context_id"),
+            "observed_at": context.get("observed_at") or context.get("fetched_at"),
+        },
+        "missions": missions,
+    }
+
+    response = JSONResponse(ok(request, data), status_code=200)
+    compute_ms = int((time.perf_counter() - start) * 1000)
+    response.headers["X-Compute-Time-ms"] = str(compute_ms)
+    return response

--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -1,15 +1,70 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime, timedelta, timezone
+import random
 from typing import Literal
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
+from redis.asyncio import Redis
 
+from app.cache import cache_key_mission_load, get_json, set_json
 from app.http_envelope import err, ok
+from app.metrics import inc_cache_hit, inc_cache_miss
 from app.settings import get_settings
+from app.services.context import build_context_snapshot
+from app.services.missions import generate_missions
 
 router = APIRouter()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _bucket_count(window: str, bucket: str) -> int:
+    days = 7 if window == "7d" else 30
+    if bucket == "day":
+        return days
+    return days * 24
+
+
+def _series_start(window: str) -> datetime:
+    days = 7 if window == "7d" else 30
+    return datetime.now(timezone.utc) - timedelta(days=days)
+
+
+def _compute_series(*, window: str, bucket: str, seed: int) -> list[dict[str, int | str]]:
+    rng = random.Random(seed)
+    count = _bucket_count(window, bucket)
+    start = _series_start(window)
+    step = timedelta(days=1) if bucket == "day" else timedelta(hours=1)
+
+    out: list[dict[str, int | str]] = []
+    base = 10 if window == "7d" else 25
+
+    # A small, bounded amount of work so compute time is non-trivial but safe.
+    work_factor = 2000 if bucket == "day" else 400
+
+    for i in range(count):
+        ts = (start + step * i).replace(minute=0, second=0, microsecond=0)
+
+        acc = 0
+        for _ in range(work_factor):
+            acc ^= rng.randint(0, 2**31 - 1)
+
+        missions_total = base + (acc % 30)
+        missions_completed = int(missions_total * (0.35 + (acc % 25) / 100.0))
+        out.append(
+            {
+                "ts": ts.isoformat().replace("+00:00", "Z"),
+                "missions_total": missions_total,
+                "missions_completed": missions_completed,
+            }
+        )
+
+    return out
 
 
 @router.get("/report")
@@ -32,35 +87,17 @@ async def report(
 
     _ = get_settings()  # keeps version/env available for future use
 
+    context = await build_context_snapshot(debug=False)
+    missions = generate_missions(context=context, limit=10, seed=42)
+    series = _compute_series(window=window, bucket=bucket, seed=42)
+
     data = {
-        "context": {
-            "context_id": "ctx_placeholder",
-            "observed_at": "2026-01-21T09:00:00Z",
-            "weather": {"city": "Istanbul", "temp_c": 7, "condition": "rain"},
-            "github": {"open_issues": 12, "open_prs": 4},
-            "news": [{"title": "Example headline", "url": "https://example.com"}],
-        },
-        "missions": [
-            {
-                "id": "msn_001",
-                "title": "Bugün yağmur var: dışarı planını 18:00 sonrası yap",
-                "priority": "P2",
-                "status": "open",
-                "due_at": None,
-                "tags": ["weather", "planning"],
-                "why": "Yağmur 14:00–17:00 arası yoğun görünüyor.",
-                "actions": [
-                    {"label": "Hava detayına git", "type": "link", "target": "/ui/context#weather"}
-                ],
-                "evidence": {"sources": ["weather"], "confidence": 0.78},
-            }
-        ],
+        "context": context,
+        "missions": missions,
         "metrics": {
             "window": window,
             "bucket": bucket,
-            "series": [
-                {"ts": "2026-01-20T00:00:00Z", "missions_total": 12, "missions_completed": 5}
-            ],
+            "series": series,
         },
     }
 
@@ -69,4 +106,66 @@ async def report(
     compute_ms = int((time.perf_counter() - start) * 1000)
     response.headers["X-Compute-Time-ms"] = str(compute_ms)
 
+    return response
+
+
+@router.get("/reports/mission-load")
+async def mission_load(
+    request: Request,
+    window: str = Query("30d"),
+    bucket: Literal["hour", "day"] = Query("hour"),
+    seed: int | None = Query(None, description="Deterministic seed (enables caching)"),
+):
+    if window not in ("7d", "30d"):
+        payload, status = err(
+            request,
+            code="INVALID_PARAMS",
+            message="window must be 7d or 30d",
+            status_code=400,
+            details={"window": window},
+        )
+        return JSONResponse(payload, status_code=status)
+
+    settings = get_settings()
+    redis: Redis = request.app.state.redis
+
+    cache_enabled = seed is not None
+    used_seed = seed if seed is not None else 42
+
+    start = time.perf_counter()
+    cache_key = cache_key_mission_load(window=window, bucket=bucket, seed=used_seed)
+
+    cached = None
+    if cache_enabled:
+        cached = await get_json(redis, cache_key)
+
+    if cached is not None:
+        inc_cache_hit()
+        data = cached["data"]
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "HIT"
+        response.headers["X-Cache-Key"] = cache_key
+        response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+    else:
+        inc_cache_miss()
+        series = _compute_series(window=window, bucket=bucket, seed=used_seed)
+        data = {
+            "window": window,
+            "bucket": bucket,
+            "seed": used_seed if cache_enabled else None,
+            "generated_at": _now_iso(),
+            "series": series,
+        }
+
+        if cache_enabled:
+            await set_json(redis, cache_key, {"data": data}, ttl_seconds=settings.cache_ttl_seconds)
+
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "MISS"
+        if cache_enabled:
+            response.headers["X-Cache-Key"] = cache_key
+            response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+
+    compute_ms = int((time.perf_counter() - start) * 1000)
+    response.headers["X-Compute-Time-ms"] = str(compute_ms)
     return response

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import context, health, report, synthetic
+from app.api.v1.endpoints import context, health, missions, report, synthetic
 
 api_router = APIRouter()
 
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(context.router, tags=["context"])
+api_router.include_router(missions.router, tags=["missions"])
 api_router.include_router(synthetic.router, tags=["synthetic"])
 api_router.include_router(report.router, tags=["report"])

--- a/backend/app/cache.py
+++ b/backend/app/cache.py
@@ -24,6 +24,10 @@ def cache_key_report(*, window: str, bucket: str) -> str:
     return f"cache:v1:report:window={window}:bucket={bucket}"
 
 
+def cache_key_mission_load(*, window: str, bucket: str, seed: int) -> str:
+    return f"cache:v1:mission_load:window={window}:bucket={bucket}:seed={seed}"
+
+
 async def get_json(redis: Redis, key: str) -> Optional[dict[str, Any]]:
     raw = await redis.get(key)
     if raw is None:

--- a/backend/app/services/context.py
+++ b/backend/app/services/context.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from app.services.ingestion.github import fetch_github
+from app.services.ingestion.news import fetch_news
+from app.services.ingestion.weather import fetch_weather
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _missing(*names: str) -> list[str]:
+    out: list[str] = []
+    for name in names:
+        if not os.getenv(name):
+            out.append(name)
+    return out
+
+
+async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) -> dict[str, Any]:
+    """Aggregate multiple external sources into a single normalized context dict.
+
+    Contract notes:
+    - Always returns a normalized schema.
+    - Exposes source health lists (ok/failed/skipped) to support UI resilience.
+    - Raw payloads are included only when debug=true.
+    """
+
+    observed_at = _now_iso()
+    context_id = f"ctx_{uuid.uuid4().hex[:12]}"
+
+    data: dict[str, Any] = {
+        "context_id": context_id,
+        "observed_at": observed_at,
+        # backward-compatible alias (will be deprecated in docs)
+        "fetched_at": observed_at,
+        "weather": None,
+        "github": None,
+        "news": [],
+        "calendar": {"events_today": 0},
+        "sources_ok": [],
+        "sources_failed": [],
+        "sources_skipped": [],
+    }
+
+    # Weather
+    missing_weather = _missing("WEATHER_LAT", "WEATHER_LON")
+    if missing_weather:
+        data["sources_skipped"].append(
+            {
+                "source": "weather",
+                "reason": f"Missing required env vars: {', '.join(missing_weather)}",
+            }
+        )
+    else:
+        try:
+            w = await fetch_weather()
+            weather_obj: dict[str, Any] = {
+                "city": os.getenv("WEATHER_CITY", "Unknown"),
+                "lat": os.getenv("WEATHER_LAT"),
+                "lon": os.getenv("WEATHER_LON"),
+                "tz": os.getenv("WEATHER_TZ"),
+                "temp_c": w.get("temp") if isinstance(w, dict) else None,
+                "condition": w.get("condition") if isinstance(w, dict) else None,
+            }
+            if debug:
+                weather_obj["raw"] = w if isinstance(w, dict) else {"value": w}
+            data["weather"] = weather_obj
+            data["sources_ok"].append("weather")
+        except Exception as e:
+            data["sources_failed"].append({"source": "weather", "error": str(e)})
+
+    # GitHub
+    missing_github = _missing("GITHUB_OWNER", "GITHUB_REPO")
+    if missing_github:
+        data["sources_skipped"].append(
+            {
+                "source": "github",
+                "reason": f"Missing required env vars: {', '.join(missing_github)}",
+            }
+        )
+    else:
+        try:
+            g = await fetch_github()
+            github_obj: dict[str, Any] = {
+                "owner": os.getenv("GITHUB_OWNER"),
+                "repo": os.getenv("GITHUB_REPO"),
+                "open_issues": g.get("open_issues") if isinstance(g, dict) else None,
+                "open_prs": g.get("open_prs") if isinstance(g, dict) else None,
+            }
+            if debug:
+                github_obj["raw"] = g if isinstance(g, dict) else {"value": g}
+            data["github"] = github_obj
+            data["sources_ok"].append("github")
+        except Exception as e:
+            data["sources_failed"].append({"source": "github", "error": str(e)})
+
+    # News (Hacker News via Algolia)
+    try:
+        data["news"] = await fetch_news(limit=news_limit)
+        data["sources_ok"].append("news")
+    except Exception as e:
+        data["sources_failed"].append({"source": "news", "error": str(e)})
+
+    return data

--- a/backend/app/services/missions.py
+++ b/backend/app/services/missions.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal, Optional
+
+
+Priority = Literal["P1", "P2", "P3", "P4"]
+Status = Literal["open", "done", "snoozed"]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _iso_in_hours(hours: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _energy_bonus(energy_level: Optional[str]) -> float:
+    if energy_level == "high":
+        return 0.15
+    if energy_level == "low":
+        return -0.10
+    return 0.0
+
+
+def generate_missions(
+    *,
+    context: dict[str, Any],
+    preferences: Optional[dict[str, Any]] = None,
+    limit: int = 15,
+    seed: Optional[int] = None,
+) -> list[dict[str, Any]]:
+    """Generate a demo-friendly mission list from context.
+
+    The goal is explainability and determinism (when seed is provided), not ML.
+    """
+
+    rng = random.Random(seed)
+    preferences = preferences or {}
+
+    weather = context.get("weather") or {}
+    github = context.get("github") or {}
+    news = context.get("news") or []
+
+    energy_level = preferences.get("energy_level")
+
+    missions: list[dict[str, Any]] = []
+
+    def add(
+        *,
+        title: str,
+        priority: Priority,
+        tags: list[str],
+        why: str,
+        sources: list[str],
+        due_at: Optional[str] = None,
+        confidence: float = 0.7,
+        actions: Optional[list[dict[str, str]]] = None,
+    ) -> None:
+        idx = len(missions) + 1
+        missions.append(
+            {
+                "id": f"msn_{idx:03d}",
+                "title": title,
+                "priority": priority,
+                "status": "open",
+                "due_at": due_at,
+                "tags": tags,
+                "why": why,
+                "actions": actions
+                or [
+                    {"label": "Context detayına git", "type": "link", "target": "/context"}
+                ],
+                "evidence": {
+                    "sources": sources,
+                    "confidence": max(0.0, min(1.0, float(confidence))),
+                },
+            }
+        )
+
+    # Rule 1: Weather-driven planning
+    condition = (weather.get("condition") or "").lower()
+    temp_c = weather.get("temp_c")
+    if condition in ("rain", "snow"):
+        add(
+            title="Dış planları güncelle (hava kötü)",
+            priority="P2",
+            tags=["weather", "planning"],
+            why=f"Hava durumu '{condition}' görünüyor; dış aktiviteleri ertele veya iç mekana al.",
+            sources=["weather"],
+            due_at=_iso_in_hours(4),
+            confidence=0.78 + _energy_bonus(energy_level),
+        )
+    elif condition:
+        add(
+            title="Gün planını hava durumuna göre ayarla",
+            priority="P3",
+            tags=["weather", "planning"],
+            why=f"Hava durumu '{condition}'. Küçük plan optimizasyonu önerildi.",
+            sources=["weather"],
+            due_at=_iso_in_hours(8),
+            confidence=0.62 + _energy_bonus(energy_level),
+        )
+
+    if isinstance(temp_c, (int, float)) and temp_c <= 2:
+        add(
+            title="Soğuk hava: dışarı çıkışları azalt",
+            priority="P3",
+            tags=["weather", "health"],
+            why=f"Sıcaklık {temp_c}°C; kısa/az dış aktivite daha güvenli.",
+            sources=["weather"],
+            due_at=_iso_in_hours(6),
+            confidence=0.66,
+        )
+
+    # Rule 2: GitHub workload pressure
+    open_prs = github.get("open_prs")
+    open_issues = github.get("open_issues")
+
+    if isinstance(open_prs, int) and open_prs >= 5:
+        add(
+            title="PR kuyruğunu temizle (review/merge)",
+            priority="P1",
+            tags=["github", "delivery"],
+            why=f"Açık PR sayısı {open_prs}; review gecikmesi risk oluşturuyor.",
+            sources=["github"],
+            due_at=_iso_in_hours(3),
+            confidence=0.82,
+            actions=[
+                {"label": "PR listesine git", "type": "link", "target": "https://github.com"}
+            ],
+        )
+    elif isinstance(open_prs, int) and open_prs > 0:
+        add(
+            title="Açık PR'leri sırala ve önceliklendir",
+            priority="P2",
+            tags=["github", "planning"],
+            why=f"{open_prs} açık PR var; en kritik olanları seç.",
+            sources=["github"],
+            due_at=_iso_in_hours(6),
+            confidence=0.74,
+        )
+
+    if isinstance(open_issues, int) and open_issues >= 10:
+        add(
+            title="Issue triage yap (etiketle/assign et)",
+            priority="P2",
+            tags=["github", "maintenance"],
+            why=f"Açık issue sayısı {open_issues}; backlog büyüyor.",
+            sources=["github"],
+            due_at=_iso_in_hours(12),
+            confidence=0.72,
+        )
+
+    # Rule 3: News-driven awareness
+    if isinstance(news, list) and len(news) > 0:
+        top = news[0]
+        top_title = top.get("title") if isinstance(top, dict) else None
+        add(
+            title="Gündemi tarayıp 5dk özet çıkar",
+            priority="P4",
+            tags=["news", "awareness"],
+            why=f"Öne çıkan başlık: {top_title}" if top_title else "Gündem verisi mevcut.",
+            sources=["news"],
+            due_at=_iso_in_hours(24),
+            confidence=0.55,
+        )
+
+    # Fillers: deterministic small tasks to reach limit
+    filler_titles = [
+        "Bugünün 3 hedefini yaz",
+        "Inbox temizliği (10dk)",
+        "Plan: 1 saat deep work blokla",
+        "Kısa mola + su iç",
+        "Yarın için 1 risk notu",
+    ]
+
+    while len(missions) < limit:
+        title = rng.choice(filler_titles)
+        pr: Priority = rng.choice(["P2", "P3", "P4"])
+        add(
+            title=title,
+            priority=pr,
+            tags=["routine"],
+            why="Deterministik demo görevi (seed ile sabit).",
+            sources=["synthetic"],
+            due_at=None,
+            confidence=0.40,
+            actions=[{"label": "Lab'a git", "type": "link", "target": "/lab"}],
+        )
+
+    # Add generated-at for easier UI display
+    for m in missions:
+        m.setdefault("generated_at", _now_iso())
+
+    return missions[:limit]

--- a/backend/tests/test_mission_load_report.py
+++ b/backend/tests/test_mission_load_report.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+
+from app.cache import cache_key_mission_load
+from app.main import create_app
+
+
+def test_mission_load_report_cache_proof(redis_client):
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    app = create_app()
+
+    cache_key = cache_key_mission_load(window="7d", bucket="day", seed=42)
+    redis_client.delete(cache_key)
+
+    with TestClient(app) as client:
+        r1 = client.get("/api/v1/reports/mission-load?window=7d&bucket=day&seed=42")
+        assert r1.status_code == 200
+        assert r1.headers.get("X-Cache") == "MISS"
+        assert r1.headers.get("X-Cache-Key") == cache_key
+        assert r1.headers.get("X-Compute-Time-ms")
+
+        r2 = client.get("/api/v1/reports/mission-load?window=7d&bucket=day&seed=42")
+        assert r2.status_code == 200
+        assert r2.headers.get("X-Cache") == "HIT"
+        assert r2.headers.get("X-Cache-Key") == cache_key
+        assert r2.headers.get("X-Compute-Time-ms")
+
+        body = r2.json()
+        assert body["ok"] is True
+        assert body["data"]["window"] == "7d"
+        assert body["data"]["bucket"] == "day"
+        assert isinstance(body["data"]["series"], list)
+        assert len(body["data"]["series"]) == 7

--- a/backend/tests/test_missions.py
+++ b/backend/tests/test_missions.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_missions_generate_accepts_explicit_context_and_returns_missions():
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    app = create_app()
+
+    body = {
+        "context": {
+            "context_id": "ctx_test",
+            "observed_at": "2026-01-22T00:00:00Z",
+            "weather": {"condition": "rain", "temp_c": 8, "city": "Istanbul"},
+            "github": {"open_prs": 6, "open_issues": 12},
+            "news": [{"title": "Example", "url": "https://example.com"}],
+        },
+        "preferences": {"energy_level": "medium", "time_of_day": "morning"},
+        "limit": 12,
+        "seed": 42,
+    }
+
+    with TestClient(app) as client:
+        res = client.post("/api/v1/missions/generate", json=body)
+        assert res.status_code == 200
+        assert res.headers.get("X-Request-Id")
+        assert res.headers.get("X-Compute-Time-ms")
+
+        payload = res.json()
+        assert payload["ok"] is True
+        assert isinstance(payload["data"]["missions"], list)
+        assert len(payload["data"]["missions"]) == 12
+
+        first = payload["data"]["missions"][0]
+        assert "id" in first
+        assert "title" in first
+        assert "priority" in first
+        assert "why" in first

--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -49,7 +49,8 @@ For cacheable endpoints, the server MUST return:
 
 ### Cacheable endpoints
 - `GET /api/v1/synthetic/tasks`
-- `GET /api/v1/report` (optional; not required for sprint 1)
+- `GET /api/v1/reports/mission-load`
+- `GET /api/v1/report` (optional; demo aggregator)
 
 ## Endpoints
 
@@ -76,6 +77,7 @@ For cacheable endpoints, the server MUST return:
 - Purpose: Return the latest aggregated context snapshot (ingestion output).
 - Query params (optional):
 	- `at`: ISO timestamp (returns snapshot closest to time)
+	- `debug`: boolean (if true, includes raw payloads for troubleshooting)
 - Cache: optional (short TTL ok).
 - Success (`200`) example:
 ```json
@@ -84,17 +86,65 @@ For cacheable endpoints, the server MUST return:
 	"data": {
 		"context_id": "ctx_01H...",
 		"observed_at": "2026-01-21T09:00:00Z",
-		"weather": {"city": "Istanbul", "temp_c": 7, "condition": "rain"},
+		"weather": {"city": "Istanbul", "lat": "41.01", "lon": "28.97", "tz": "Europe/Istanbul", "temp_c": 7, "condition": "rain"},
 		"news": [{"title": "Example headline", "url": "https://example.com"}],
-		"github": {"open_issues": 12, "open_prs": 4},
-		"calendar": {"events_today": 3}
+		"github": {"owner": "miclaldogan", "repo": "jarvis-mission-control", "open_issues": 12, "open_prs": 4},
+		"calendar": {"events_today": 0},
+		"sources_ok": ["weather", "github", "news"],
+		"sources_failed": [{"source": "weather", "error": "..."}],
+		"sources_skipped": [{"source": "github", "reason": "Missing required env vars: GITHUB_OWNER, GITHUB_REPO"}]
 	},
 	"meta": {"request_id": "req_01H...", "ts": "2026-01-21T12:00:00Z"}
 }
 ```
 - Errors:
-	- `NOT_FOUND` (404) if no context exists yet.
-	- `INVALID_PARAMS` (400) for invalid `at`.
+	- `INVALID_PARAMS` (400) for invalid query params.
+	- `UPSTREAM_FAILED` (502) only when **all** sources fail or are skipped.
+
+### POST /api/v1/missions/generate
+- Purpose: Generate a mission/task list from context with explainable “why”.
+- Body:
+	- `context` (optional): object; if omitted, server uses live context ingestion.
+	- `preferences` (optional): `{ energy_level: low|medium|high, time_of_day: morning|afternoon|evening }`
+	- `limit` (optional): int 1..30 (default 15)
+	- `seed` (optional): int; makes output deterministic
+- Cache: optional (not enabled by default).
+- Success (`200`) example:
+```json
+{
+	"ok": true,
+	"data": {
+		"context": {"context_id": "ctx_01H...", "observed_at": "2026-01-21T09:00:00Z"},
+		"missions": [
+			{
+				"id": "msn_001",
+				"title": "PR kuyruğunu temizle (review/merge)",
+				"priority": "P1",
+				"status": "open",
+				"due_at": "2026-01-22T15:00:00Z",
+				"tags": ["github", "delivery"],
+				"why": "Açık PR sayısı 6; review gecikmesi risk oluşturuyor.",
+				"actions": [{"label": "PR listesine git", "type": "link", "target": "https://github.com"}],
+				"evidence": {"sources": ["github"], "confidence": 0.82}
+			}
+		]
+	},
+	"meta": {"request_id": "req_01H...", "ts": "2026-01-21T12:00:00Z"}
+}
+```
+
+### GET /api/v1/reports/mission-load
+- Purpose: Heavy-compute demo report over a time window (used for cache proof).
+- Query params:
+	- `window`: `7d|30d` (default `30d`)
+	- `bucket`: `hour|day` (default `hour`)
+	- `seed` (optional, recommended): deterministic generation; enables caching
+- Cache:
+	- Cache ON if `seed` is provided.
+	- Cache OFF if `seed` missing.
+- Success (`200`) includes:
+	- `data.series[]` each with `{ts, missions_total, missions_completed}`
+- Headers (when cached): `X-Cache`, `X-Compute-Time-ms`, optional `X-Cache-Key`.
 
 ### GET /api/v1/synthetic/tasks
 - Purpose: Generate synthetic tasks for load/performance demos.

--- a/docs/context_schema.md
+++ b/docs/context_schema.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The internal `ContextSnapshot` is the normalized data model used by the backend to aggregate contextual information from multiple sources (weather, calendar, news, GitHub). 
+The `ContextSnapshot` is the normalized data model used by the backend to aggregate contextual information from multiple sources (weather, news, GitHub).
 
 The **v1 public API** returns a normalized `Context` object via `GET /api/v1/context` wrapped in the standard [response envelope](api_contract.md#response-envelope-standard).
 
-**Note:** Internal ingestion logic and error tracking (sources_ok, sources_failed) are implementation details. The v1 contract exposes only clean, aggregated fields.
+**Note:** For UI resilience and demo clarity, v1 also exposes source health lists (`sources_ok`, `sources_failed`, `sources_skipped`). Raw upstream payloads are included only when `debug=true`.
 
 ## Context Data Model (Public v1 API)
 
@@ -16,25 +16,18 @@ Exposed via `GET /api/v1/context` in the `data` field of the standard response e
 |-------|------|-------------|
 | `context_id` | string | Unique identifier for this snapshot (e.g., `ctx_01H...`) |
 | `observed_at` | string (ISO 8601, UTC) | Timestamp when data was aggregated; format: `YYYY-MM-DDTHH:mm:ssZ` |
+| `fetched_at` | string (ISO 8601, UTC) | Backward-compatible alias of `observed_at` (planned deprecation) |
 | `weather` | WeatherContext \| null | Current weather conditions, or null if unavailable |
-| `calendar` | object | Calendar summary (e.g., `{events_today: 3}`) |
+| `calendar` | object | Calendar summary (placeholder for now; e.g., `{events_today: 0}`) |
 | `news` | array | List of news articles |
 | `github` | GitHubContext \| null | GitHub repository stats, or null if unavailable |
+| `sources_ok` | array of strings | Names of sources that ingested successfully |
+| `sources_failed` | array of objects | Sources that failed; each has `{source: string, error: string}` |
+| `sources_skipped` | array of objects | Sources skipped due to missing config; each has `{source: string, reason: string}` |
 
-## Internal ContextSnapshot (Backend)
+## Debug payloads
 
-Used internally during ingestion; not exposed directly in v1 API.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `context_id` | string | Unique identifier for this snapshot |
-| `observed_at` | string (ISO 8601, UTC) | Timestamp when data was fetched |
-| `weather` | WeatherContext \| null | Current weather conditions |
-| `calendar` | array | List of calendar events |
-| `news` | array | List of news articles |
-| `github` | GitHubContext \| null | GitHub repository stats |
-| `sources_ok` | array of strings | **[Internal only]** Names of sources that ingested successfully |
-| `sources_failed` | array of objects | **[Internal only]** Sources that failed; each has `{source: string, error: string}` |
+When calling `GET /api/v1/context?debug=true`, the server may attach per-source raw payloads (e.g., `weather.raw`, `github.raw`) for troubleshooting.
 
 ### WeatherContext
 


### PR DESCRIPTION
Adds POST /api/v1/missions/generate (explainable missions, deterministic seed) and GET /api/v1/reports/mission-load (heavy compute + Redis cache proof headers). Also refactors /api/v1/context to a shared aggregator with sources_ok/failed/skipped and debug raw payloads, updates docs, and adds deterministic tests.