### PR TITLE
cache: add short TTL caching for /api/v1/context

### DIFF
--- a/backend/app/api/v1/endpoints/context.py
+++ b/backend/app/api/v1/endpoints/context.py
@@ -19,13 +19,14 @@ router = APIRouter()
 def _context_cache_key(request: Request) -> str:
     # Include *all* query params (incl. debug) in the key.
     # Sort for stability so ordering differences don't cause cache misses.
-    items = sorted(request.query_params.multi_items())
+    # Note: refresh=true is a cache bypass flag and must NOT create a separate cache key.
+    items = sorted([(k, v) for (k, v) in request.query_params.multi_items() if k != "refresh"])
     query = "&".join([f"{k}={v}" for k, v in items])
     return f"cache:v1:context:path={request.url.path}:q={query}"
 
 
 @router.get("/context")
-async def get_context(request: Request, debug: bool = Query(False)):
+async def get_context(request: Request, debug: bool = Query(False), refresh: bool = Query(False)):
     """
     Return latest aggregated context snapshot.
 
@@ -42,17 +43,18 @@ async def get_context(request: Request, debug: bool = Query(False)):
     redis: Redis = request.app.state.redis
     cache_key = _context_cache_key(request)
 
-    cached = await get_json(redis, cache_key)
-    if cached is not None:
-        inc_cache_hit()
-        data = cached.get("data")
-        response = JSONResponse(ok(request, data), status_code=200)
-        response.headers["X-Cache"] = "HIT"
-        response.headers["X-Cache-Key"] = cache_key
-        response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
-        compute_ms = int((time.perf_counter() - start) * 1000)
-        response.headers["X-Compute-Time-ms"] = str(compute_ms)
-        return response
+    if not refresh:
+        cached = await get_json(redis, cache_key)
+        if cached is not None:
+            inc_cache_hit()
+            data = cached.get("data")
+            response = JSONResponse(ok(request, data), status_code=200)
+            response.headers["X-Cache"] = "HIT"
+            response.headers["X-Cache-Key"] = cache_key
+            response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+            compute_ms = int((time.perf_counter() - start) * 1000)
+            response.headers["X-Compute-Time-ms"] = str(compute_ms)
+            return response
 
     inc_cache_miss()
 

--- a/backend/tests/test_context_cache.py
+++ b/backend/tests/test_context_cache.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _clear_context_cache(client) -> None:
+    keys = client.keys("cache:v1:context:*")
+    if keys:
+        client.delete(*keys)
+
+
+def test_context_cache_proof_headers_and_refresh(redis_client, monkeypatch):
+    async def fake_build_context_snapshot(*, debug: bool = False, news_limit: int = 5):
+        base = {
+            "context_id": "ctx_test",
+            "observed_at": "2026-01-01T00:00:00Z",
+            "fetched_at": "2026-01-01T00:00:00Z",
+            "weather": None,
+            "github": None,
+            "news": [],
+            "calendar": {"events_today": 0},
+            "sources_ok": ["news"],
+            "sources_failed": [],
+            "sources_skipped": [],
+        }
+        if debug:
+            base["debug"] = True
+        return base
+
+    import app.api.v1.endpoints.context as context_ep
+
+    monkeypatch.setattr(context_ep, "build_context_snapshot", fake_build_context_snapshot)
+    _clear_context_cache(redis_client)
+
+    client = TestClient(app)
+
+    r1 = client.get("/api/v1/context")
+    assert r1.status_code == 200
+    assert r1.headers.get("X-Cache") == "MISS"
+
+    r2 = client.get("/api/v1/context")
+    assert r2.status_code == 200
+    assert r2.headers.get("X-Cache") == "HIT"
+    assert r2.headers.get("X-Cache-Key") == r1.headers.get("X-Cache-Key")
+
+    # refresh=true bypasses cache read and forces compute (but updates same cache key)
+    r3 = client.get("/api/v1/context?refresh=true")
+    assert r3.status_code == 200
+    assert r3.headers.get("X-Cache") == "MISS"
+    assert r3.headers.get("X-Cache-Key") == r1.headers.get("X-Cache-Key")
+
+    # debug=true should use a different cache key
+    r4 = client.get("/api/v1/context?debug=true")
+    assert r4.status_code == 200
+    assert r4.headers.get("X-Cache") == "MISS"
+    assert r4.headers.get("X-Cache-Key") != r1.headers.get("X-Cache-Key")
+
+    r5 = client.get("/api/v1/context?debug=true")
+    assert r5.status_code == 200
+    assert r5.headers.get("X-Cache") == "HIT"
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_context_cache_hit_miss(monkeypatch):
+    # deterministic snapshot
+    async def fake_build_context_snapshot(debug: bool = False):
+        return {
+            "fetched_at": "2026-01-01T00:00:00Z",
+            "weather": None,
+            "github": None,
+            "news": [],
+            "sources_ok": ["news"],
+            "sources_failed": [],
+            "sources_skipped": [],
+        }
+
+    # patch the function used by endpoint
+    import app.api.v1.endpoints.context as context_ep
+    monkeypatch.setattr(context_ep, "build_context_snapshot", fake_build_context_snapshot)
+
+    client = TestClient(app)
+
+    r1 = client.get("/api/v1/context")
+    assert r1.status_code == 200
+    assert r1.json()["data"]["cache"] == "MISS"
+
+    r2 = client.get("/api/v1/context")
+    assert r2.status_code == 200
+    assert r2.json()["data"]["cache"] == "HIT"
+
+    # refresh bypass should force MISS
+    r3 = client.get("/api/v1/context?refresh=true")
+    assert r3.status_code == 200
+    assert r3.json()["data"]["cache"] == "MISS"

--- a/backend/tests/test_context_cache.py
+++ b/backend/tests/test_context_cache.py
@@ -39,6 +39,7 @@ def test_context_cache_proof_headers_and_refresh(redis_client, monkeypatch):
     r1 = client.get("/api/v1/context")
     assert r1.status_code == 200
     assert r1.headers.get("X-Cache") == "MISS"
+    assert r1.headers.get("X-Cache-Key")
 
     r2 = client.get("/api/v1/context")
     assert r2.status_code == 200
@@ -60,39 +61,4 @@ def test_context_cache_proof_headers_and_refresh(redis_client, monkeypatch):
     r5 = client.get("/api/v1/context?debug=true")
     assert r5.status_code == 200
     assert r5.headers.get("X-Cache") == "HIT"
-from fastapi.testclient import TestClient
 
-from app.main import app
-
-
-def test_context_cache_hit_miss(monkeypatch):
-    # deterministic snapshot
-    async def fake_build_context_snapshot(debug: bool = False):
-        return {
-            "fetched_at": "2026-01-01T00:00:00Z",
-            "weather": None,
-            "github": None,
-            "news": [],
-            "sources_ok": ["news"],
-            "sources_failed": [],
-            "sources_skipped": [],
-        }
-
-    # patch the function used by endpoint
-    import app.api.v1.endpoints.context as context_ep
-    monkeypatch.setattr(context_ep, "build_context_snapshot", fake_build_context_snapshot)
-
-    client = TestClient(app)
-
-    r1 = client.get("/api/v1/context")
-    assert r1.status_code == 200
-    assert r1.json()["data"]["cache"] == "MISS"
-
-    r2 = client.get("/api/v1/context")
-    assert r2.status_code == 200
-    assert r2.json()["data"]["cache"] == "HIT"
-
-    # refresh bypass should force MISS
-    r3 = client.get("/api/v1/context?refresh=true")
-    assert r3.status_code == 200
-    assert r3.json()["data"]["cache"] == "MISS"

--- a/backend/tests/test_context_cache.py
+++ b/backend/tests/test_context_cache.py
@@ -34,31 +34,30 @@ def test_context_cache_proof_headers_and_refresh(redis_client, monkeypatch):
     monkeypatch.setattr(context_ep, "build_context_snapshot", fake_build_context_snapshot)
     _clear_context_cache(redis_client)
 
-    client = TestClient(app)
+    with TestClient(app) as client:
+        r1 = client.get("/api/v1/context")
+        assert r1.status_code == 200
+        assert r1.headers.get("X-Cache") == "MISS"
+        assert r1.headers.get("X-Cache-Key")
 
-    r1 = client.get("/api/v1/context")
-    assert r1.status_code == 200
-    assert r1.headers.get("X-Cache") == "MISS"
-    assert r1.headers.get("X-Cache-Key")
+        r2 = client.get("/api/v1/context")
+        assert r2.status_code == 200
+        assert r2.headers.get("X-Cache") == "HIT"
+        assert r2.headers.get("X-Cache-Key") == r1.headers.get("X-Cache-Key")
 
-    r2 = client.get("/api/v1/context")
-    assert r2.status_code == 200
-    assert r2.headers.get("X-Cache") == "HIT"
-    assert r2.headers.get("X-Cache-Key") == r1.headers.get("X-Cache-Key")
+        # refresh=true bypasses cache read and forces compute (but updates same cache key)
+        r3 = client.get("/api/v1/context?refresh=true")
+        assert r3.status_code == 200
+        assert r3.headers.get("X-Cache") == "MISS"
+        assert r3.headers.get("X-Cache-Key") == r1.headers.get("X-Cache-Key")
 
-    # refresh=true bypasses cache read and forces compute (but updates same cache key)
-    r3 = client.get("/api/v1/context?refresh=true")
-    assert r3.status_code == 200
-    assert r3.headers.get("X-Cache") == "MISS"
-    assert r3.headers.get("X-Cache-Key") == r1.headers.get("X-Cache-Key")
+        # debug=true should use a different cache key
+        r4 = client.get("/api/v1/context?debug=true")
+        assert r4.status_code == 200
+        assert r4.headers.get("X-Cache") == "MISS"
+        assert r4.headers.get("X-Cache-Key") != r1.headers.get("X-Cache-Key")
 
-    # debug=true should use a different cache key
-    r4 = client.get("/api/v1/context?debug=true")
-    assert r4.status_code == 200
-    assert r4.headers.get("X-Cache") == "MISS"
-    assert r4.headers.get("X-Cache-Key") != r1.headers.get("X-Cache-Key")
-
-    r5 = client.get("/api/v1/context?debug=true")
-    assert r5.status_code == 200
-    assert r5.headers.get("X-Cache") == "HIT"
+        r5 = client.get("/api/v1/context?debug=true")
+        assert r5.status_code == 200
+        assert r5.headers.get("X-Cache") == "HIT"
 

--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -46,6 +46,7 @@ For cacheable endpoints, the server MUST return:
 - `X-Compute-Time-ms: <int>`
 - `X-Cache-Key: <string>` (optional but recommended as proof)
 - `Cache-Control: public, max-age=<seconds>` (or `private` if needed)
+- When cache is bypassed (e.g. `refresh=true`), `X-Cache: MISS` MUST be returned.
 
 ### Cacheable endpoints
 - `GET /api/v1/synthetic/tasks`
@@ -76,8 +77,8 @@ For cacheable endpoints, the server MUST return:
 ### GET /api/v1/context
 - Purpose: Return the latest aggregated context snapshot (ingestion output).
 - Query params (optional):
-	- `at`: ISO timestamp (returns snapshot closest to time)
 	- `debug`: boolean (if true, includes raw payloads for troubleshooting)
+	- `refresh`: boolean (if true, bypasses cache and forces a fresh fetch)
 - Cache: optional (short TTL ok).
 - Success (`200`) example:
 ```json


### PR DESCRIPTION
## Summary
Adds short-TTL caching for GET /api/v1/context with explicit cache headers.
Supports refresh=true cache bypass and separates cache keys by debug flag.

## Issue link
- Closes #46

## How to test
1. Start backend
2. Call GET /api/v1/context → X-Cache: MISS
3. Call again → X-Cache: HIT
4. Call with refresh=true → MISS
5. Call with debug=true → separate cache key

## Proof
- X-Cache / X-Compute-Time-ms / X-Cache-Key headers verified
- Deterministic test added: `test_context_cache.py`
