### PR TITLE
fix(backend): normalize error codes to uppercase RATE_LIMITED

### DIFF
--- a/backend/app/api/v1/endpoints/synthetic.py
+++ b/backend/app/api/v1/endpoints/synthetic.py
@@ -82,7 +82,7 @@ async def synthetic_tasks(
         if not allowed:
             payload, status = err(
                 request,
-                code="rate_limited",
+                code="RATE_LIMITED",
                 message="Too many requests",
                 status_code=429,
                 details={"limit": limit, "window_seconds": window_seconds},

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -39,7 +39,7 @@ def test_synthetic_tasks_rate_limited(redis_client, monkeypatch):
 
         body = r3.json()
         assert body["ok"] is False
-        assert body["error"]["code"] == "rate_limited"
+        assert body["error"]["code"] == "RATE_LIMITED"
         assert body["error"]["details"]["limit"] == 2
         assert body["error"]["details"]["window_seconds"] == 3600
         assert body["meta"]["request_id"] == r3.headers["X-Request-Id"]


### PR DESCRIPTION
## Summary
- Change `rate_limited` to `RATE_LIMITED` in synthetic endpoint
- Update test assertion to match
- All error codes now follow uppercase format per `docs/api_contract.md`

## Done Checklist
- [x] All endpoints use consistent casing/format (RATE_LIMITED, UPSTREAM_FAILED, INVALID_PARAMS, INTERNAL)
- [x] Tests assert error.code for rate limit path
- [x] CI green

Closes #50