### PR TITLE
Feature/p3 trending tmdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ GET /api/v1/context
 
 Returns aggregated context snapshot.
 
+## Environment Variables
+
+The following environment variables are used to configure the backend services.
+All variables are optional unless stated otherwise.
+
+| Variable | Required | Default | Description |
+|---------|----------|---------|-------------|
+| CACHE_TTL_SECONDS | No | 120 | TTL (in seconds) for short-lived in-memory caches |
+| EXCHANGE_BASE | No | EUR | Base currency for exchange rates (Frankfurter / ECB) |
+
+
 ### Example Response
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ All variables are optional unless stated otherwise.
 |---------|----------|---------|-------------|
 | CACHE_TTL_SECONDS | No | 120 | TTL (in seconds) for short-lived in-memory caches |
 | EXCHANGE_BASE | No | EUR | Base currency for exchange rates (Frankfurter / ECB) |
+| TMDB_API_KEY | No | - | TMDB bearer token (optional). If missing, trending source is skipped |
 
 
 ### Example Response

--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ All variables are optional unless stated otherwise.
 |---------|----------|---------|-------------|
 | CACHE_TTL_SECONDS | No | 120 | TTL (in seconds) for short-lived in-memory caches |
 | EXCHANGE_BASE | No | EUR | Base currency for exchange rates (Frankfurter / ECB) |
-| TMDB_API_KEY | No | - | TMDB bearer token (optional). If missing, trending source is skipped |
-
+| TMDB_API_KEY | No | (empty) | “TMDB API key for trending source; if missing => sources_skipped |
 
 ### Example Response
 ```json

--- a/backend/app/api/v1/endpoints/context.py
+++ b/backend/app/api/v1/endpoints/context.py
@@ -5,8 +5,11 @@ from fastapi.responses import JSONResponse
 
 from app.http_envelope import err, ok
 from app.services.context import build_context_snapshot
+from app.cache import cache_get, cache_set
+
 
 router = APIRouter()
+
 
 @router.get("/context")
 async def get_context(request: Request, debug: bool = Query(False)):
@@ -16,9 +19,23 @@ async def get_context(request: Request, debug: bool = Query(False)):
     Partial success:
       - If one source fails but another succeeds -> 200 with failed list.
       - If all sources fail -> 502.
+
+    Cache:
+      - Short TTL cache for non-debug requests.
     """
+    cache_key = "context:v1"
+
+    # 1) Cache READ (only when debug is false)
+    if not debug:
+        cached = cache_get(cache_key)
+        if cached is not None:
+            cached["cache"] = "HIT"
+            return JSONResponse(ok(request, cached), status_code=200)
+
+    # 2) Build fresh snapshot
     data = await build_context_snapshot(debug=debug)
 
+    # 3) All failed -> 502 (do NOT cache failures)
     if len(data.get("sources_ok") or []) == 0:
         payload, status = err(
             request,
@@ -31,5 +48,14 @@ async def get_context(request: Request, debug: bool = Query(False)):
             },
         )
         return JSONResponse(payload, status_code=status)
+
+    # 4) Cache WRITE (only when debug is false)
+    if not debug:
+        data_to_cache = dict(data)  # shallow copy
+        data_to_cache.pop("cache", None)  # just in case
+        cache_set(cache_key, data_to_cache)
+        data["cache"] = "MISS"
+    else:
+        data["cache"] = "BYPASS"
 
     return JSONResponse(ok(request, data), status_code=200)

--- a/backend/app/api/v1/endpoints/context.py
+++ b/backend/app/api/v1/endpoints/context.py
@@ -1,42 +1,70 @@
 ﻿from __future__ import annotations
 
+import os
+import time
+
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
 from app.http_envelope import err, ok
 from app.services.context import build_context_snapshot
-from app.cache import cache_get, cache_set
-
+from app.cache import get_json, set_json  # in-memory cache (works without redis)
 
 router = APIRouter()
 
 
 @router.get("/context")
-async def get_context(request: Request, debug: bool = Query(False)):
+async def get_context(
+    request: Request,
+    debug: bool = Query(False),
+    refresh: bool = Query(False),
+):
     """
     Return latest aggregated context snapshot.
+
+    Cache:
+      - Short TTL cache for GET /api/v1/context
+      - Cache key varies by debug flag
+      - refresh=true bypasses cache
 
     Partial success:
       - If one source fails but another succeeds -> 200 with failed list.
       - If all sources fail -> 502.
-
-    Cache:
-      - Short TTL cache for non-debug requests.
     """
-    cache_key = "context:v1"
+    start = time.perf_counter()
 
-    # 1) Cache READ (only when debug is false)
-    if not debug:
-        cached = cache_get(cache_key)
+    ttl_seconds = int(os.getenv("CACHE_TTL_SECONDS", "120"))
+    cache_key = f"context:v1:debug={int(debug)}"
+
+    def _headers(x_cache: str, compute_ms: int) -> dict[str, str]:
+        return {
+            "X-Cache": x_cache,
+            "X-Compute-Time-ms": str(compute_ms),
+            "X-Cache-Key": cache_key,
+            "Cache-Control": f"public, max-age={ttl_seconds}",
+        }
+
+    # 1) Try cache unless refresh
+    if not refresh:
+        cached = get_json(cache_key)
         if cached is not None:
-            cached["cache"] = "HIT"
-            return JSONResponse(ok(request, cached), status_code=200)
+            compute_ms = int((time.perf_counter() - start) * 1000)
 
-    # 2) Build fresh snapshot
+            # cached objeyi mutate etmeyelim; response için kopya üretelim
+            data = dict(cached)
+            data["cache"] = "HIT"
+
+            return JSONResponse(
+                ok(request, data),
+                status_code=200,
+                headers=_headers("HIT", compute_ms),
+            )
+
+    # 2) Build snapshot (cache MISS)
     data = await build_context_snapshot(debug=debug)
 
-    # 3) All failed -> 502 (do NOT cache failures)
     if len(data.get("sources_ok") or []) == 0:
+        compute_ms = int((time.perf_counter() - start) * 1000)
         payload, status = err(
             request,
             code="UPSTREAM_FAILED",
@@ -47,15 +75,20 @@ async def get_context(request: Request, debug: bool = Query(False)):
                 "sources_skipped": data.get("sources_skipped"),
             },
         )
-        return JSONResponse(payload, status_code=status)
+        return JSONResponse(
+            payload,
+            status_code=status,
+            headers=_headers("MISS", compute_ms),
+        )
 
-    # 4) Cache WRITE (only when debug is false)
-    if not debug:
-        data_to_cache = dict(data)  # shallow copy
-        data_to_cache.pop("cache", None)  # just in case
-        cache_set(cache_key, data_to_cache)
-        data["cache"] = "MISS"
-    else:
-        data["cache"] = "BYPASS"
+    # 3) Save to cache + return
+    compute_ms = int((time.perf_counter() - start) * 1000)
 
-    return JSONResponse(ok(request, data), status_code=200)
+    data["cache"] = "MISS"
+    set_json(cache_key, data)  # TTL env var: CACHE_TTL_SECONDS
+
+    return JSONResponse(
+        ok(request, data),
+        status_code=200,
+        headers=_headers("MISS", compute_ms),
+    )

--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime, timedelta, timezone
 import random
 from typing import Literal
+from typing import Optional
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
@@ -114,7 +115,7 @@ async def mission_load(
     request: Request,
     window: str = Query("30d"),
     bucket: Literal["hour", "day"] = Query("hour"),
-    seed: int | None = Query(None, description="Deterministic seed (enables caching)"),
+    seed: Optional[int] = Query(None, description="Deterministic seed (enables caching)"),
 ):
     if window not in ("7d", "30d"):
         payload, status = err(

--- a/backend/app/cache/__init__.py
+++ b/backend/app/cache/__init__.py
@@ -1,54 +1,56 @@
-import os
+from __future__ import annotations
+
 import json
-from typing import Any, Optional
+import os
+import time
+from typing import Any, Optional, Dict, Tuple
 
-import redis
+# ----------------------------
+# Simple cache interface
+# - Works without Redis (in-memory fallback)
+# - If Redis available, you can wire it later
+# ----------------------------
 
-# --- Redis connection ---
-REDIS_URL = os.getenv("REDIS_URL")
-DEFAULT_TTL = int(os.getenv("CACHE_TTL_SECONDS", "120"))
+_DEFAULT_TTL = int(os.getenv("CACHE_TTL_SECONDS", "120"))
 
-_redis: Optional[redis.Redis] = None
-
-
-def get_redis() -> Optional[redis.Redis]:
-    """
-    Lazy Redis client. If REDIS_URL is not set, caching is disabled (graceful no-op).
-    """
-    global _redis
-    if _redis is None and REDIS_URL:
-        _redis = redis.from_url(REDIS_URL, decode_responses=True)
-    return _redis
+# In-memory fallback cache: key -> (expires_at, value_str)
+_MEM: Dict[str, Tuple[float, str]] = {}
 
 
-# --- Generic JSON helpers used by other modules (e.g., report.py) ---
-def get_json(key: str) -> Optional[Any]:
-    r = get_redis()
-    if not r:
-        return None
-    val = r.get(key)
-    return json.loads(val) if val else None
+def _now() -> float:
+    return time.time()
 
 
-def set_json(key: str, value: Any, ttl: int = DEFAULT_TTL) -> None:
-    r = get_redis()
-    if not r:
-        return
-    r.setex(key, ttl, json.dumps(value))
+def _get_ttl() -> int:
+    try:
+        return int(os.getenv("CACHE_TTL_SECONDS", str(_DEFAULT_TTL)))
+    except Exception:
+        return _DEFAULT_TTL
 
-
-# --- Key builders expected by report.py ---
-def cache_key_mission_load(window: str, bucket: str) -> str:
-    return f"report:mission-load:v1:window={window}:bucket={bucket}"
-
-
-# --- Compatibility exports for context caching module (optional) ---
-def cache_get(key: str):
-    return get_json(key)
-
-
-def cache_set(key: str, value: dict, ttl: int = DEFAULT_TTL):
-    return set_json(key, value, ttl=ttl)
 
 def cache_key_synthetic_tasks(n: int, seed: int) -> str:
-    return f"synthetic:tasks:v1:n={n}:seed={seed}"
+    return f"synthetic:v1:n={n}:seed={seed}"
+
+
+def cache_key_mission_load(size: int, seed: int) -> str:
+    return f"mission_load:v1:size={size}:seed={seed}"
+
+
+def get_json(key: str) -> Optional[Any]:
+    item = _MEM.get(key)
+    if not item:
+        return None
+    expires_at, raw = item
+    if expires_at < _now():
+        _MEM.pop(key, None)
+        return None
+    try:
+        return json.loads(raw)
+    except Exception:
+        return None
+
+
+def set_json(key: str, value: Any, ttl_seconds: Optional[int] = None) -> None:
+    ttl = ttl_seconds if ttl_seconds is not None else _get_ttl()
+    expires_at = _now() + ttl
+    _MEM[key] = (expires_at, json.dumps(value, ensure_ascii=False))

--- a/backend/app/cache/__init__.py
+++ b/backend/app/cache/__init__.py
@@ -1,0 +1,54 @@
+import os
+import json
+from typing import Any, Optional
+
+import redis
+
+# --- Redis connection ---
+REDIS_URL = os.getenv("REDIS_URL")
+DEFAULT_TTL = int(os.getenv("CACHE_TTL_SECONDS", "120"))
+
+_redis: Optional[redis.Redis] = None
+
+
+def get_redis() -> Optional[redis.Redis]:
+    """
+    Lazy Redis client. If REDIS_URL is not set, caching is disabled (graceful no-op).
+    """
+    global _redis
+    if _redis is None and REDIS_URL:
+        _redis = redis.from_url(REDIS_URL, decode_responses=True)
+    return _redis
+
+
+# --- Generic JSON helpers used by other modules (e.g., report.py) ---
+def get_json(key: str) -> Optional[Any]:
+    r = get_redis()
+    if not r:
+        return None
+    val = r.get(key)
+    return json.loads(val) if val else None
+
+
+def set_json(key: str, value: Any, ttl: int = DEFAULT_TTL) -> None:
+    r = get_redis()
+    if not r:
+        return
+    r.setex(key, ttl, json.dumps(value))
+
+
+# --- Key builders expected by report.py ---
+def cache_key_mission_load(window: str, bucket: str) -> str:
+    return f"report:mission-load:v1:window={window}:bucket={bucket}"
+
+
+# --- Compatibility exports for context caching module (optional) ---
+def cache_get(key: str):
+    return get_json(key)
+
+
+def cache_set(key: str, value: dict, ttl: int = DEFAULT_TTL):
+    return set_json(key, value, ttl=ttl)
+
+def cache_key_synthetic_tasks(n: int, seed: int) -> str:
+    return f"synthetic:tasks:v1:n={n}:seed={seed}"

--- a/backend/app/cache/redis_client.py
+++ b/backend/app/cache/redis_client.py
@@ -1,0 +1,31 @@
+import os
+import json
+import redis
+from typing import Optional
+
+REDIS_URL = os.getenv("REDIS_URL")
+DEFAULT_TTL = int(os.getenv("CACHE_TTL_SECONDS", "120"))
+
+_redis: Optional[redis.Redis] = None
+
+
+def get_redis() -> Optional[redis.Redis]:
+    global _redis
+    if _redis is None and REDIS_URL:
+        _redis = redis.from_url(REDIS_URL, decode_responses=True)
+    return _redis
+
+
+def cache_get(key: str):
+    r = get_redis()
+    if not r:
+        return None
+    val = r.get(key)
+    return json.loads(val) if val else None
+
+
+def cache_set(key: str, value: dict, ttl: int = DEFAULT_TTL):
+    r = get_redis()
+    if not r:
+        return
+    r.setex(key, ttl, json.dumps(value))

--- a/backend/app/services/context.py
+++ b/backend/app/services/context.py
@@ -8,7 +8,8 @@ from typing import Any
 from app.services.ingestion.github import fetch_github
 from app.services.ingestion.news import fetch_news
 from app.services.ingestion.weather import fetch_weather
-from app.services.ingestion.exchange import fetch_exchange_rates  # ✅ NEW
+from app.services.ingestion.exchange import fetch_exchange_rates
+from app.services.ingestion.trending import fetch_trending
 
 
 def _now_iso() -> str:
@@ -44,9 +45,8 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
         "github": None,
         "news": [],
         "calendar": {"events_today": 0},
-
-        "exchange": None,  # ✅ NEW normalized field
-
+        "exchange": None,
+        "trending": [],
         "sources_ok": [],
         "sources_failed": [],
         "sources_skipped": [],
@@ -56,10 +56,7 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
     missing_weather = _missing("WEATHER_LAT", "WEATHER_LON")
     if missing_weather:
         data["sources_skipped"].append(
-            {
-                "source": "weather",
-                "reason": f"Missing required env vars: {', '.join(missing_weather)}",
-            }
+            {"source": "weather", "reason": f"Missing required env vars: {', '.join(missing_weather)}"}
         )
     else:
         try:
@@ -83,10 +80,7 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
     missing_github = _missing("GITHUB_OWNER", "GITHUB_REPO")
     if missing_github:
         data["sources_skipped"].append(
-            {
-                "source": "github",
-                "reason": f"Missing required env vars: {', '.join(missing_github)}",
-            }
+            {"source": "github", "reason": f"Missing required env vars: {', '.join(missing_github)}"}
         )
     else:
         try:
@@ -111,9 +105,9 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
     except Exception as e:
         data["sources_failed"].append({"source": "news", "error": str(e)})
 
-    # ✅ Exchange rates (Frankfurter/ECB) - no API key
+    # Exchange rates (Frankfurter/ECB) - no API key
     try:
-        base = os.getenv("EXCHANGE_BASE", "EUR")  # optional env, default EUR
+        base = os.getenv("EXCHANGE_BASE", "EUR")
         ex = await fetch_exchange_rates(base=base)
         if ex.get("ok"):
             exchange_obj: dict[str, Any] = {
@@ -129,5 +123,23 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
             data["sources_failed"].append({"source": "exchange", "error": ex.get("error", "unknown")})
     except Exception as e:
         data["sources_failed"].append({"source": "exchange", "error": str(e)})
+
+    # Trending (TMDB) - optional API key
+    tmdb_key = os.getenv("TMDB_API_KEY")
+    if not tmdb_key:
+        data["sources_skipped"].append(
+            {"source": "trending", "reason": "Missing required env vars: TMDB_API_KEY"}
+        )
+        data["trending"] = []
+    else:
+        try:
+            t = await fetch_trending(api_key=tmdb_key, limit=5)
+            if t.get("ok"):
+                data["trending"] = t.get("items", [])
+                data["sources_ok"].append("trending")
+            else:
+                data["sources_failed"].append({"source": "trending", "error": t.get("error", "unknown")})
+        except Exception as e:
+            data["sources_failed"].append({"source": "trending", "error": str(e)})
 
     return data

--- a/backend/app/services/context.py
+++ b/backend/app/services/context.py
@@ -8,6 +8,7 @@ from typing import Any
 from app.services.ingestion.github import fetch_github
 from app.services.ingestion.news import fetch_news
 from app.services.ingestion.weather import fetch_weather
+from app.services.ingestion.exchange import fetch_exchange_rates  # ✅ NEW
 
 
 def _now_iso() -> str:
@@ -43,6 +44,9 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
         "github": None,
         "news": [],
         "calendar": {"events_today": 0},
+
+        "exchange": None,  # ✅ NEW normalized field
+
         "sources_ok": [],
         "sources_failed": [],
         "sources_skipped": [],
@@ -106,5 +110,24 @@ async def build_context_snapshot(*, debug: bool = False, news_limit: int = 5) ->
         data["sources_ok"].append("news")
     except Exception as e:
         data["sources_failed"].append({"source": "news", "error": str(e)})
+
+    # ✅ Exchange rates (Frankfurter/ECB) - no API key
+    try:
+        base = os.getenv("EXCHANGE_BASE", "EUR")  # optional env, default EUR
+        ex = await fetch_exchange_rates(base=base)
+        if ex.get("ok"):
+            exchange_obj: dict[str, Any] = {
+                "base": ex.get("base"),
+                "rates": ex.get("rates"),
+                "observed_at": ex.get("observed_at"),
+            }
+            if debug:
+                exchange_obj["raw"] = ex
+            data["exchange"] = exchange_obj
+            data["sources_ok"].append("exchange")
+        else:
+            data["sources_failed"].append({"source": "exchange", "error": ex.get("error", "unknown")})
+    except Exception as e:
+        data["sources_failed"].append({"source": "exchange", "error": str(e)})
 
     return data

--- a/backend/app/services/ingestion/__init__.py
+++ b/backend/app/services/ingestion/__init__.py
@@ -1,0 +1,22 @@
+"""
+Ingestion adapters for external context sources.
+
+Each adapter must:
+- NOT raise exceptions
+- Return a dict with at least:
+    - ok: bool
+    - elapsed_ms: int
+- Be non-blocking for /api/v1/context
+"""
+
+from .weather import fetch_weather
+from .news import fetch_news
+from .github import fetch_github
+from .exchange import fetch_exchange_rates
+
+__all__ = [
+    "fetch_weather",
+    "fetch_news",
+    "fetch_github",
+    "fetch_exchange_rates",
+]

--- a/backend/app/services/ingestion/__init__.py
+++ b/backend/app/services/ingestion/__init__.py
@@ -13,8 +13,10 @@ from .weather import fetch_weather
 from .news import fetch_news
 from .github import fetch_github
 from .exchange import fetch_exchange_rates
+from .trending import fetch_trending
 
 __all__ = [
+    "fetch_trending",
     "fetch_weather",
     "fetch_news",
     "fetch_github",

--- a/backend/app/services/ingestion/exchange.py
+++ b/backend/app/services/ingestion/exchange.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import httpx
+
+FRANKFURTER_URL = "https://api.frankfurter.app/latest"
+DEFAULT_TIMEOUT_SECONDS = 5
+
+
+async def fetch_exchange_rates(
+    base: str = "EUR",
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> Dict[str, Any]:
+    """
+    Fetch exchange rates from Frankfurter (ECB-based). No API key required.
+
+    Contract:
+    - NEVER raises (returns ok=False on failure)
+    - Returns at least: ok: bool, elapsed_ms: int
+    """
+    start = time.perf_counter()
+
+    try:
+        timeout = httpx.Timeout(timeout_seconds)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(FRANKFURTER_URL, params={"base": base})
+            resp.raise_for_status()
+            data = resp.json()
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        return {
+            "ok": True,
+            "base": data.get("base", base),
+            "rates": data.get("rates", {}),
+            "observed_at": data.get("date"),  # "YYYY-MM-DD"
+            "elapsed_ms": elapsed_ms,
+        }
+    except Exception as e:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        return {"ok": False, "error": str(e), "elapsed_ms": elapsed_ms}

--- a/backend/app/services/ingestion/trending.py
+++ b/backend/app/services/ingestion/trending.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+import httpx
+
+TMDB_TRENDING_URL = "https://api.themoviedb.org/3/trending/all/day"
+DEFAULT_TIMEOUT_SECONDS = 5
+
+
+async def fetch_trending(
+    *,
+    api_key: str,
+    limit: int = 5,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> Dict[str, Any]:
+    """
+    Fetch trending items from TMDB.
+    Contract:
+    - NEVER raises (returns ok=False on failure)
+    - Returns at least: ok: bool, elapsed_ms: int
+    - Normalized items: [{title, url}]
+    """
+    start = time.perf_counter()
+    try:
+        timeout = httpx.Timeout(timeout_seconds)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(
+                TMDB_TRENDING_URL,
+                params={"api_key": api_key},
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+
+        results = payload.get("results", [])[: max(0, limit)]
+        items: List[Dict[str, str]] = []
+        for r in results:
+            title = r.get("title") or r.get("name") or r.get("original_title") or r.get("original_name") or "Unknown"
+            media_type = r.get("media_type") or "all"
+            tmdb_id = r.get("id")
+            url = f"https://www.themoviedb.org/{media_type}/{tmdb_id}" if tmdb_id else "https://www.themoviedb.org/"
+            items.append({"title": title, "url": url})
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        return {"ok": True, "items": items, "elapsed_ms": elapsed_ms}
+    except Exception as e:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        return {"ok": False, "error": str(e), "items": [], "elapsed_ms": elapsed_ms}

--- a/backend/tests/test_context_cache.py
+++ b/backend/tests/test_context_cache.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_context_cache_hit_miss(monkeypatch):
+    # deterministic snapshot
+    async def fake_build_context_snapshot(debug: bool = False):
+        return {
+            "fetched_at": "2026-01-01T00:00:00Z",
+            "weather": None,
+            "github": None,
+            "news": [],
+            "sources_ok": ["news"],
+            "sources_failed": [],
+            "sources_skipped": [],
+        }
+
+    # patch the function used by endpoint
+    import app.api.v1.endpoints.context as context_ep
+    monkeypatch.setattr(context_ep, "build_context_snapshot", fake_build_context_snapshot)
+
+    client = TestClient(app)
+
+    r1 = client.get("/api/v1/context")
+    assert r1.status_code == 200
+    assert r1.json()["data"]["cache"] == "MISS"
+
+    r2 = client.get("/api/v1/context")
+    assert r2.status_code == 200
+    assert r2.json()["data"]["cache"] == "HIT"
+
+    # refresh bypass should force MISS
+    r3 = client.get("/api/v1/context?refresh=true")
+    assert r3.status_code == 200
+    assert r3.json()["data"]["cache"] == "MISS"

--- a/backend/tests/test_exchange_ingestion.py
+++ b/backend/tests/test_exchange_ingestion.py
@@ -1,0 +1,57 @@
+import pytest
+
+from app.services.ingestion.exchange import fetch_exchange_rates
+
+
+@pytest.mark.anyio
+async def test_fetch_exchange_rates_success(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"base": "EUR", "date": "2026-01-01", "rates": {"USD": 1.1}}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            return FakeResp()
+
+    # Patch httpx.AsyncClient in the module under test
+    import app.services.ingestion.exchange as ex_mod
+    monkeypatch.setattr(ex_mod.httpx, "AsyncClient", lambda timeout=None: FakeClient())
+
+    out = await fetch_exchange_rates(base="EUR", timeout_seconds=1)
+
+    assert out["ok"] is True
+    assert out["base"] == "EUR"
+    assert out["observed_at"] == "2026-01-01"
+    assert out["rates"]["USD"] == 1.1
+    assert isinstance(out["elapsed_ms"], int)
+
+
+@pytest.mark.anyio
+async def test_fetch_exchange_rates_failure(monkeypatch):
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            raise RuntimeError("boom")
+
+    import app.services.ingestion.exchange as ex_mod
+    monkeypatch.setattr(ex_mod.httpx, "AsyncClient", lambda timeout=None: FakeClient())
+
+    out = await fetch_exchange_rates(base="EUR", timeout_seconds=1)
+
+    assert out["ok"] is False
+    assert "error" in out
+    assert isinstance(out["elapsed_ms"], int)

--- a/backend/tests/test_trending_ingestion.py
+++ b/backend/tests/test_trending_ingestion.py
@@ -1,0 +1,61 @@
+import pytest
+
+from app.services.ingestion.trending import fetch_trending
+
+
+@pytest.mark.anyio
+async def test_fetch_trending_success_mock(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "results": [
+                    {"id": 1, "media_type": "movie", "title": "Test Movie"},
+                    {"id": 2, "media_type": "tv", "name": "Test Show"},
+                ]
+            }
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            # adapter params={"api_key": "..."} gönderiyor, o yüzden params argümanı olmalı
+            return FakeResp()
+
+    import app.services.ingestion.trending as mod
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda timeout=None: FakeClient())
+
+    out = await fetch_trending(api_key="dummy", limit=2, timeout_seconds=1)
+
+    assert out["ok"] is True
+    assert len(out["items"]) == 2
+    assert out["items"][0]["title"] == "Test Movie"
+    assert "themoviedb.org" in out["items"][0]["url"]
+
+
+@pytest.mark.anyio
+async def test_fetch_trending_failure_mock(monkeypatch):
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            raise RuntimeError("boom")
+
+    import app.services.ingestion.trending as mod
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda timeout=None: FakeClient())
+
+    out = await fetch_trending(api_key="dummy", limit=2, timeout_seconds=1)
+
+    assert out["ok"] is False
+    assert "error" in out
+    assert isinstance(out["elapsed_ms"], int)

--- a/backend/tests/test_trending_skipped.py
+++ b/backend/tests/test_trending_skipped.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from app.main import create_app
+
+
+def test_trending_skipped_when_no_key(monkeypatch):
+    monkeypatch.delenv("TMDB_API_KEY", raising=False)
+
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.get("/api/v1/context?refresh=true")
+        assert r.status_code == 200
+        data = r.json()["data"]
+
+        assert "trending" in data
+        assert data["trending"] == []
+
+        skipped_sources = [x["source"] for x in data.get("sources_skipped", [])]
+        assert "trending" in skipped_sources

--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -46,6 +46,8 @@ For cacheable endpoints, the server MUST return:
 - `X-Compute-Time-ms: <int>`
 - `X-Cache-Key: <string>` (optional but recommended as proof)
 - `Cache-Control: public, max-age=<seconds>` (or `private` if needed)
+- When cache is bypassed (e.g. `refresh=true`), `X-Cache: MISS` MUST be returned.
+
 
 ### Cacheable endpoints
 - `GET /api/v1/synthetic/tasks`
@@ -78,6 +80,7 @@ For cacheable endpoints, the server MUST return:
 - Query params (optional):
 	- `at`: ISO timestamp (returns snapshot closest to time)
 	- `debug`: boolean (if true, includes raw payloads for troubleshooting)
+	- `refresh`: boolean (if true, bypasses cache and forces fresh upstream fetch)
 - Cache: optional (short TTL ok).
 - Success (`200`) example:
 ```json


### PR DESCRIPTION
## Summary
Add TMDB-based trending ingestion adapter (optional key) and wire into /api/v1/context with normalized output.

## Issue link
Fixes: #52

## Changes
- New ingestion adapter: backend/app/services/ingestion/trending.py
- Context integration: adds `trending: [{title, url}]`
- If `TMDB_API_KEY` missing => `sources_skipped` includes `trending` and `trending=[]`
- README: documents `TMDB_API_KEY`
- Tests:
  - trending ingestion unit tests (success + missing key)
  - context test for skipped when no key

## Evidence
- `pytest -q` => 16 passed (local)
