### PR TITLE
docs(env): document optional ingestion environment variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,25 @@ REDIS_URL=redis://redis:6379/0
 
 # Cache
 CACHE_TTL_SECONDS=120
+
+########################################
+# Optional Ingestion Sources
+########################################
+
+# Optional: Trending Movies (TMDB API)
+# Used by: services/ingestion/trending.py
+# Get your API key at: https://www.themoviedb.org/settings/api
+TMDB_API_KEY=
+
+# Optional: Traffic Data
+# Used by: services/ingestion/traffic.py
+# Supported providers: Google Maps, HERE, TomTom
+TRAFFIC_API_KEY=
+# Coordinates format: latitude,longitude
+TRAFFIC_ORIGIN=41.0082,28.9784        # Istanbul
+TRAFFIC_DESTINATION=40.7128,-74.0060  # Example destination
+
+# Optional: Exchange Rates
+# Used by: services/ingestion/exchange.py
+# Base currency for conversions (default: USD)
+EXCHANGE_BASE_CURRENCY=USD


### PR DESCRIPTION
## Summary
Documents optional environment variables used by ingestion sources and adds clear guidance for local setup.

## Issue link
Fixes #77

## Changes
- Added missing optional ingestion environment variables to `backend/.env.example`
- Documented usage, example values, and API documentation links
- Grouped related variables and kept consistent formatting

## Evidence
- Updated `.env.example` includes TMDB, Traffic, and Exchange configuration blocks

## How to test
1. Copy `.env.example` to `.env`
2. Start the backend without optional API keys
3. Verify ingestion sources are skipped gracefully without errors
