### PR TITLE
fix(frontend): correct nginx.conf COPY path for docker build context

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,8 @@ FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy nginx config
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary
Fixes the frontend Docker image build by correcting the nginx.conf COPY path to match the Docker build context.

## Issue link
Fixes CI docker-build failure

## Changes
- Updated COPY path in `frontend/Dockerfile` to correctly reference `nginx.conf`

## Evidence
- CI docker-build was failing due to missing file in build context
- This change aligns the COPY path with the frontend build context

## How to test
```bash
docker build -f frontend/Dockerfile frontend
