### PR TITLE
feat: Mission Detail Endpoint with History Tracking (#99)

### DIFF
--- a/backend/app/api/v1/endpoints/missions.py
+++ b/backend/app/api/v1/endpoints/missions.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from app.http_envelope import ok
 from app.services.context import build_context_snapshot
 from app.services.missions import generate_missions
+from app.services import storage
 
 router = APIRouter()
 
@@ -114,6 +115,10 @@ async def missions_generate(request: Request, body: MissionsGenerateRequest):
         limit=body.limit,
         seed=body.seed,
     )
+    
+    # Store generated missions in memory
+    for mission in missions:
+        storage.store_mission(mission)
 
     data = {
         "context": {
@@ -124,6 +129,102 @@ async def missions_generate(request: Request, body: MissionsGenerateRequest):
     }
 
     response = JSONResponse(ok(request, data), status_code=200)
+    compute_ms = int((time.perf_counter() - start) * 1000)
+    response.headers["X-Compute-Time-ms"] = str(compute_ms)
+    return response
+
+
+@router.get("/missions/{mission_id}")
+async def get_mission_detail(request: Request, mission_id: str):
+    """
+    Get mission detail with full history.
+    
+    Returns the mission object plus a timeline of all state changes.
+    Useful for debugging why a mission has certain priority or status.
+    """
+    start = time.perf_counter()
+    
+    mission = storage.get_mission(mission_id)
+    if not mission:
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": {
+                    "code": "MISSION_NOT_FOUND",
+                    "message": f"Mission with ID '{mission_id}' does not exist",
+                },
+                "meta": {
+                    "request_id": request.headers.get("X-Request-ID", "unknown"),
+                    "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                },
+            },
+            status_code=404,
+        )
+    
+    history = storage.get_mission_history(mission_id)
+    
+    data = {
+        "mission": mission,
+        "history": history,
+        "history_count": len(history),
+    }
+    
+    response = JSONResponse(ok(request, data), status_code=200)
+    compute_ms = int((time.perf_counter() - start) * 1000)
+    response.headers["X-Compute-Time-ms"] = str(compute_ms)
+    return response
+
+
+@router.patch("/missions/{mission_id}/status")
+async def update_mission_status(
+    request: Request, mission_id: str, body: dict[str, Any]
+):
+    """
+    Update mission status (open → in_progress → done).
+    
+    Records the change in mission history.
+    """
+    start = time.perf_counter()
+    
+    new_status = body.get("status")
+    reason = body.get("reason", "")
+    
+    if not new_status:
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": {
+                    "code": "MISSING_STATUS",
+                    "message": "Request body must include 'status' field",
+                },
+                "meta": {
+                    "request_id": request.headers.get("X-Request-ID", "unknown"),
+                    "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                },
+            },
+            status_code=400,
+        )
+    
+    success = storage.update_mission_status(mission_id, new_status, reason)
+    if not success:
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": {
+                    "code": "MISSION_NOT_FOUND",
+                    "message": f"Mission with ID '{mission_id}' does not exist",
+                },
+                "meta": {
+                    "request_id": request.headers.get("X-Request-ID", "unknown"),
+                    "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                },
+            },
+            status_code=404,
+        )
+    
+    mission = storage.get_mission(mission_id)
+    
+    response = JSONResponse(ok(request, {"mission": mission}), status_code=200)
     compute_ms = int((time.perf_counter() - start) * 1000)
     response.headers["X-Compute-Time-ms"] = str(compute_ms)
     return response

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,122 @@
+"""
+In-memory storage for missions and their history.
+
+This is a temporary solution until database integration.
+All data is lost on server restart.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+from collections import defaultdict
+
+
+# Global in-memory stores
+_missions: dict[str, dict[str, Any]] = {}
+_mission_history: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+
+def store_mission(mission: dict[str, Any]) -> None:
+    """Store a mission in memory."""
+    mission_id = mission.get("id")
+    if not mission_id:
+        raise ValueError("Mission must have an 'id' field")
+    
+    _missions[mission_id] = mission.copy()
+    
+    # Add creation event to history
+    add_history_event(
+        mission_id=mission_id,
+        event_type="created",
+        reason=mission.get("why", "Mission generated"),
+        data={
+            "priority": mission.get("priority"),
+            "priority_score": mission.get("priority_score"),
+            "tags": mission.get("tags", []),
+            "due_at": mission.get("due_at"),
+        },
+    )
+
+
+def get_mission(mission_id: str) -> Optional[dict[str, Any]]:
+    """Retrieve a mission by ID."""
+    return _missions.get(mission_id)
+
+
+def get_all_missions() -> list[dict[str, Any]]:
+    """Get all stored missions."""
+    return list(_missions.values())
+
+
+def update_mission_status(mission_id: str, new_status: str, reason: str = "") -> bool:
+    """Update mission status and record in history."""
+    mission = _missions.get(mission_id)
+    if not mission:
+        return False
+    
+    old_status = mission.get("status")
+    mission["status"] = new_status
+    mission["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    
+    add_history_event(
+        mission_id=mission_id,
+        event_type="status_changed",
+        reason=reason or f"Status changed from {old_status} to {new_status}",
+        data={"old_status": old_status, "new_status": new_status},
+    )
+    
+    return True
+
+
+def update_mission_priority(
+    mission_id: str, new_priority: str, new_score: float, reason: str = ""
+) -> bool:
+    """Update mission priority and record in history."""
+    mission = _missions.get(mission_id)
+    if not mission:
+        return False
+    
+    old_priority = mission.get("priority")
+    old_score = mission.get("priority_score")
+    
+    mission["priority"] = new_priority
+    mission["priority_score"] = new_score
+    mission["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    
+    add_history_event(
+        mission_id=mission_id,
+        event_type="priority_changed",
+        reason=reason or f"Priority recalculated: {old_priority} ({old_score:.2f}) → {new_priority} ({new_score:.2f})",
+        data={
+            "old_priority": old_priority,
+            "new_priority": new_priority,
+            "old_score": old_score,
+            "new_score": new_score,
+        },
+    )
+    
+    return True
+
+
+def add_history_event(
+    mission_id: str, event_type: str, reason: str, data: Optional[dict[str, Any]] = None
+) -> None:
+    """Add a history event for a mission."""
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "event_type": event_type,
+        "reason": reason,
+        "data": data or {},
+    }
+    _mission_history[mission_id].append(event)
+
+
+def get_mission_history(mission_id: str) -> list[dict[str, Any]]:
+    """Get history for a specific mission."""
+    return _mission_history.get(mission_id, [])
+
+
+def clear_all() -> None:
+    """Clear all stored missions and history (for testing)."""
+    _missions.clear()
+    _mission_history.clear()


### PR DESCRIPTION
## Summary
Implements mission detail endpoint with full history tracking.

## Changes
- ✅ Created `storage.py` for in-memory mission persistence
- ✅ Added `GET /api/v1/missions/{mission_id}` endpoint
- ✅ Added `PATCH /api/v1/missions/{mission_id}/status` endpoint
- ✅ Auto-store all generated missions
- ✅ Track mission history (creation, status changes)

## API Examples

### Get Mission Detail
```bash
GET /api/v1/missions/msn_001
```

**Response:**
```json
{
  "mission": {
    "id": "msn_001",
    "title": "Gün planını hava durumuna göre ayarla",
    "priority": "P3",
    "status": "open",
    ...
  },
  "history": [
    {
      "event_type": "created",
      "reason": "Hava durumu 'cloudy'. Küçük plan optimizasyonu önerildi.",
      "timestamp": "2026-01-24T20:14:52.804516Z"
    }
  ]
}
```

### Update Mission Status
```bash
PATCH /api/v1/missions/msn_001/status
{"status": "in_progress", "reason": "User started working"}
```

## Testing
✅ Generated missions stored automatically  
✅ Detail endpoint returns mission + history  
✅ Status update recorded in history  
✅ 404 returned for non-existent missions  

## Notes
- In-memory storage (resets on restart)
- Ready for DB migration later
- Satisfies #99 acceptance criteria

Closes #99