### PR TITLE
feat(#105): Heavy report endpoints with cache proof

### DIFF
--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 import time
 from datetime import datetime, timedelta, timezone
 import random
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional, Any
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 
-from app.cache import cache_key_mission_load, get_json, set_json
+from app.cache import (
+    cache_key_mission_load,
+    cache_key_priority_distribution,
+    cache_key_category_breakdown,
+    get_json,
+    set_json,
+)
 from app.http_envelope import err, ok
 from app.metrics import inc_cache_hit, inc_cache_miss
 from app.settings import get_settings
@@ -37,6 +42,10 @@ def _series_start(window: str) -> datetime:
 
 
 def _compute_series(*, window: str, bucket: str, seed: int) -> list[dict[str, int | str]]:
+    """
+    Deterministic series generator for mission load report.
+    Compute is bounded but non-trivial to support cache proof demos.
+    """
     rng = random.Random(seed)
     count = _bucket_count(window, bucket)
     start = _series_start(window)
@@ -68,6 +77,103 @@ def _compute_series(*, window: str, bucket: str, seed: int) -> list[dict[str, in
     return out
 
 
+def _compute_priority_distribution(*, window: str, buckets: int, seed: int) -> dict[str, Any]:
+    """
+    Compute-heavy-ish histogram over synthetic priorities.
+    buckets: number of histogram bins, e.g. 10/50/100
+    """
+    rng = random.Random(seed)
+
+    # Work size depends on window to make 30d typically heavier than 7d.
+    n = 140_000 if window == "30d" else 90_000
+    hist = [0] * buckets
+
+    # bounded work to keep endpoint safe
+    extra_work = 700 if window == "30d" else 450
+
+    for _ in range(n):
+        p = rng.random()  # 0..1
+        idx = int(p * buckets)
+        if idx >= buckets:
+            idx = buckets - 1
+        hist[idx] += 1
+
+        # small deterministic workload
+        acc = 0
+        for _ in range(extra_work // 70):
+            acc ^= rng.randint(0, 2**31 - 1)
+
+    bins = []
+    for i, c in enumerate(hist):
+        lo = i / buckets
+        hi = (i + 1) / buckets
+        bins.append({"range": [lo, hi], "count": c})
+
+    top_bins = sorted(bins, key=lambda x: x["count"], reverse=True)[:10]
+
+    return {
+        "total_samples": n,
+        "buckets": buckets,
+        "bins": bins,
+        "top_bins": top_bins,
+    }
+
+
+def _compute_category_breakdown(*, window: str, seed: int, top_n: int) -> dict[str, Any]:
+    """
+    Compute-heavy-ish aggregation over synthetic categories.
+    Returns top_n by count with avg_priority + avg_energy.
+    """
+    rng = random.Random(seed)
+
+    categories = ["bugfix", "research", "meeting", "admin", "study", "health", "coding", "review"]
+    n = 140_000 if window == "30d" else 90_000
+
+    stats: dict[str, dict[str, float]] = {
+        c: {"count": 0.0, "sum_priority": 0.0, "sum_energy": 0.0} for c in categories
+    }
+
+    extra_work = 800 if window == "30d" else 520
+
+    for _ in range(n):
+        c = rng.choice(categories)
+        p = rng.random()
+        e = rng.random()
+
+        s = stats[c]
+        s["count"] += 1.0
+        s["sum_priority"] += p
+        s["sum_energy"] += e
+
+        # deterministic extra work (bounded)
+        acc = 0
+        for _ in range(extra_work // 80):
+            acc ^= rng.randint(0, 2**31 - 1)
+
+    rows = []
+    for c, s in stats.items():
+        cnt = int(s["count"])
+        if cnt <= 0:
+            continue
+        rows.append(
+            {
+                "category": c,
+                "count": cnt,
+                "avg_priority": round(s["sum_priority"] / cnt, 4),
+                "avg_energy": round(s["sum_energy"] / cnt, 4),
+            }
+        )
+
+    rows.sort(key=lambda r: r["count"], reverse=True)
+
+    return {
+        "total_samples": n,
+        "top_n": top_n,
+        "items": rows[:top_n],
+    }
+
+
+# (Optional legacy route - kept as-is; not required for #105)
 @router.get("/report")
 async def report(
     request: Request,
@@ -156,6 +262,128 @@ async def mission_load(
             "seed": used_seed if cache_enabled else None,
             "generated_at": _now_iso(),
             "series": series,
+        }
+
+        if cache_enabled:
+            await set_json(redis, cache_key, {"data": data}, ttl_seconds=settings.cache_ttl_seconds)
+
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "MISS"
+        if cache_enabled:
+            response.headers["X-Cache-Key"] = cache_key
+            response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+
+    compute_ms = int((time.perf_counter() - start) * 1000)
+    response.headers["X-Compute-Time-ms"] = str(compute_ms)
+    return response
+
+
+@router.get("/reports/priority-distribution")
+async def priority_distribution(
+    request: Request,
+    window: str = Query("30d"),
+    buckets: int = Query(50, ge=5, le=200, description="Histogram bucket count (e.g., 10/50/100)"),
+    seed: Optional[int] = Query(None, description="Deterministic seed (enables caching)"),
+):
+    if window not in ("7d", "30d"):
+        payload, status = err(
+            request,
+            code="INVALID_PARAMS",
+            message="window must be 7d or 30d",
+            status_code=400,
+            details={"window": window},
+        )
+        return JSONResponse(payload, status_code=status)
+
+    settings = get_settings()
+    redis: Redis = request.app.state.redis
+
+    cache_enabled = seed is not None
+    used_seed = seed if seed is not None else 42
+
+    start = time.perf_counter()
+    cache_key = cache_key_priority_distribution(window=window, buckets=buckets, seed=used_seed)
+
+    cached = None
+    if cache_enabled:
+        cached = await get_json(redis, cache_key)
+
+    if cached is not None:
+        inc_cache_hit()
+        data = cached["data"]
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "HIT"
+        response.headers["X-Cache-Key"] = cache_key
+        response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+    else:
+        inc_cache_miss()
+        computed = _compute_priority_distribution(window=window, buckets=buckets, seed=used_seed)
+        data = {
+            "window": window,
+            "seed": used_seed if cache_enabled else None,
+            "generated_at": _now_iso(),
+            **computed,
+        }
+
+        if cache_enabled:
+            await set_json(redis, cache_key, {"data": data}, ttl_seconds=settings.cache_ttl_seconds)
+
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "MISS"
+        if cache_enabled:
+            response.headers["X-Cache-Key"] = cache_key
+            response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+
+    compute_ms = int((time.perf_counter() - start) * 1000)
+    response.headers["X-Compute-Time-ms"] = str(compute_ms)
+    return response
+
+
+@router.get("/reports/category-breakdown")
+async def category_breakdown(
+    request: Request,
+    window: str = Query("30d"),
+    top_n: int = Query(10, ge=3, le=50, description="Return top N categories"),
+    seed: Optional[int] = Query(None, description="Deterministic seed (enables caching)"),
+):
+    if window not in ("7d", "30d"):
+        payload, status = err(
+            request,
+            code="INVALID_PARAMS",
+            message="window must be 7d or 30d",
+            status_code=400,
+            details={"window": window},
+        )
+        return JSONResponse(payload, status_code=status)
+
+    settings = get_settings()
+    redis: Redis = request.app.state.redis
+
+    cache_enabled = seed is not None
+    used_seed = seed if seed is not None else 42
+
+    start = time.perf_counter()
+    cache_key = cache_key_category_breakdown(window=window, seed=used_seed, top_n=top_n)
+
+    cached = None
+    if cache_enabled:
+        cached = await get_json(redis, cache_key)
+
+    if cached is not None:
+        inc_cache_hit()
+        data = cached["data"]
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "HIT"
+        response.headers["X-Cache-Key"] = cache_key
+        response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+    else:
+        inc_cache_miss()
+        computed = _compute_category_breakdown(window=window, seed=used_seed, top_n=top_n)
+        data = {
+            "window": window,
+            "seed": used_seed if cache_enabled else None,
+            "generated_at": _now_iso(),
+            **computed,
         }
 
         if cache_enabled:

--- a/backend/app/cache.py
+++ b/backend/app/cache.py
@@ -28,6 +28,16 @@ def cache_key_mission_load(*, window: str, bucket: str, seed: int) -> str:
     return f"cache:v1:mission_load:window={window}:bucket={bucket}:seed={seed}"
 
 
+# ✅ NEW (Issue #105): Priority distribution cache key
+def cache_key_priority_distribution(*, window: str, buckets: int, seed: int) -> str:
+    return f"cache:v1:priority_distribution:window={window}:buckets={buckets}:seed={seed}"
+
+
+# ✅ NEW (Issue #105): Category breakdown cache key
+def cache_key_category_breakdown(*, window: str, top_n: int, seed: int) -> str:
+    return f"cache:v1:category_breakdown:window={window}:top_n={top_n}:seed={seed}"
+
+
 async def get_json(redis: Redis, key: str) -> Optional[dict[str, Any]]:
     raw = await redis.get(key)
     if raw is None:


### PR DESCRIPTION
## What was done
- Added heavy report endpoints:
  - GET /api/v1/reports/mission-load
  - GET /api/v1/reports/priority-distribution
  - GET /api/v1/reports/category-breakdown
- Implemented deterministic computation with optional Redis caching (seed-based).
- Added cache proof headers:
  - X-Cache (HIT / MISS)
  - X-Compute-Time-ms
  - Cache-Control

## How to test
1. Call any endpoint with a seed parameter.
2. First request returns X-Cache: MISS.
3. Second request with same params returns X-Cache: HIT.

## Notes
- Designed to demonstrate heavy computation + caching behavior for demo purposes.
