### PR TITLE
feat(#117): make cache MISS visibly slow for demo proof

### DIFF
--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -4,27 +4,27 @@ import asyncio
 import random
 import time
 from datetime import datetime, timedelta, timezone
-<<<<<<< HEAD
+
 from typing import Literal, Optional
-=======
+
 import random
 from typing import Literal, Optional, Any
->>>>>>> dev
+
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 
 from app.cache import (
-<<<<<<< HEAD
+
     cache_key_category_breakdown,
     cache_key_mission_load,
     cache_key_priority_distribution,
-=======
+
     cache_key_mission_load,
     cache_key_priority_distribution,
     cache_key_category_breakdown,
->>>>>>> dev
+
     get_json,
     set_json,
 )

--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+import asyncio
+import random
 import time
 from datetime import datetime, timedelta, timezone
-import random
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 
-from app.cache import cache_key_mission_load, get_json, set_json
+from app.cache import (
+    cache_key_category_breakdown,
+    cache_key_mission_load,
+    cache_key_priority_distribution,
+    get_json,
+    set_json,
+)
 from app.http_envelope import err, ok
 from app.metrics import inc_cache_hit, inc_cache_miss
 from app.settings import get_settings
@@ -19,9 +25,30 @@ from app.services.missions import generate_missions
 
 router = APIRouter()
 
+# Issue #117: Make MISS visibly slow for cache proof demos.
+# Target: MISS ~1500-2500ms, HIT <50ms.
+MISS_DELAY_MS = 1800  # 1600-2200 arası ayarlayabilirsin
+
+
+async def _delay_on_miss() -> None:
+    await asyncio.sleep(MISS_DELAY_MS / 1000.0)
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _validate_window(request: Request, window: str):
+    if window not in ("7d", "30d"):
+        payload, status = err(
+            request,
+            code="INVALID_PARAMS",
+            message="window must be 7d or 30d",
+            status_code=400,
+            details={"window": window},
+        )
+        return JSONResponse(payload, status_code=status)
+    return None
 
 
 def _bucket_count(window: str, bucket: str) -> int:
@@ -45,7 +72,7 @@ def _compute_series(*, window: str, bucket: str, seed: int) -> list[dict[str, in
     out: list[dict[str, int | str]] = []
     base = 10 if window == "7d" else 25
 
-    # A small, bounded amount of work so compute time is non-trivial but safe.
+    # bounded work (safe) + still non-trivial
     work_factor = 2000 if bucket == "day" else 400
 
     for i in range(count):
@@ -68,25 +95,83 @@ def _compute_series(*, window: str, bucket: str, seed: int) -> list[dict[str, in
     return out
 
 
+def _compute_priority_distribution(*, seed: int, buckets: int) -> dict[str, object]:
+    """
+    Create a histogram-like distribution for demo purposes.
+    Buckets represent priority score ranges (0-1). We output counts per bucket.
+    """
+    rng = random.Random(seed)
+    counts = [0 for _ in range(buckets)]
+
+    # simulate a large sample to make aggregation meaningful
+    n = 200_000
+    for _ in range(n):
+        # pseudo priority in [0, 1)
+        p = rng.random()
+        idx = min(int(p * buckets), buckets - 1)
+        counts[idx] += 1
+
+    series = []
+    for i, c in enumerate(counts):
+        lo = i / buckets
+        hi = (i + 1) / buckets
+        series.append({"bucket": f"{lo:.2f}-{hi:.2f}", "count": c})
+
+    return {"buckets": buckets, "total": n, "series": series}
+
+
+def _compute_category_breakdown(*, seed: int, top_n: int) -> dict[str, object]:
+    """
+    Simulate category stats (count, avg_priority, avg_energy) for demo purposes.
+    """
+    rng = random.Random(seed)
+    categories = ["SYSTEM", "RECON", "ENCRYPTION", "DEFENSE", "OPS", "RESEARCH", "DOCS", "BUGFIX"]
+
+    # simulate many tasks
+    n = 150_000
+    stats: dict[str, dict[str, float]] = {}
+    for c in categories:
+        stats[c] = {"count": 0.0, "sum_priority": 0.0, "sum_energy": 0.0}
+
+    for _ in range(n):
+        c = rng.choice(categories)
+        priority = rng.random()
+        energy = 0.2 + rng.random() * 0.8  # 0.2-1.0
+        s = stats[c]
+        s["count"] += 1.0
+        s["sum_priority"] += priority
+        s["sum_energy"] += energy
+
+    rows = []
+    for c, s in stats.items():
+        cnt = int(s["count"])
+        if cnt == 0:
+            continue
+        rows.append(
+            {
+                "category": c,
+                "count": cnt,
+                "avg_priority": round(s["sum_priority"] / cnt, 4),
+                "avg_energy": round(s["sum_energy"] / cnt, 4),
+            }
+        )
+
+    rows.sort(key=lambda r: r["count"], reverse=True)
+    return {"total": n, "top_n": top_n, "rows": rows[:top_n]}
+
+
 @router.get("/report")
 async def report(
     request: Request,
     window: str = Query("30d"),
     bucket: Literal["hour", "day"] = Query("hour"),
 ):
-    if window not in ("7d", "30d"):
-        payload, status = err(
-            request,
-            code="INVALID_PARAMS",
-            message="window must be 7d or 30d",
-            status_code=400,
-            details={"window": window},
-        )
-        return JSONResponse(payload, status_code=status)
+    bad = _validate_window(request, window)
+    if bad is not None:
+        return bad
 
     start = time.perf_counter()
-
-    _ = get_settings()  # keeps version/env available for future use
+    _ = get_settings()
 
     context = await build_context_snapshot(debug=False)
     missions = generate_missions(context=context, limit=10, seed=42)
@@ -95,18 +180,11 @@ async def report(
     data = {
         "context": context,
         "missions": missions,
-        "metrics": {
-            "window": window,
-            "bucket": bucket,
-            "series": series,
-        },
+        "metrics": {"window": window, "bucket": bucket, "series": series},
     }
 
     response = JSONResponse(ok(request, data), status_code=200)
-
-    compute_ms = int((time.perf_counter() - start) * 1000)
-    response.headers["X-Compute-Time-ms"] = str(compute_ms)
-
+    response.headers["X-Compute-Time-ms"] = str(int((time.perf_counter() - start) * 1000))
     return response
 
 
@@ -117,15 +195,9 @@ async def mission_load(
     bucket: Literal["hour", "day"] = Query("hour"),
     seed: Optional[int] = Query(None, description="Deterministic seed (enables caching)"),
 ):
-    if window not in ("7d", "30d"):
-        payload, status = err(
-            request,
-            code="INVALID_PARAMS",
-            message="window must be 7d or 30d",
-            status_code=400,
-            details={"window": window},
-        )
-        return JSONResponse(payload, status_code=status)
+    bad = _validate_window(request, window)
+    if bad is not None:
+        return bad
 
     settings = get_settings()
     redis: Redis = request.app.state.redis
@@ -149,6 +221,11 @@ async def mission_load(
         response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
     else:
         inc_cache_miss()
+
+        # Issue #117: make MISS visibly slow (only when cache demo is enabled)
+        if cache_enabled:
+            await _delay_on_miss()
+
         series = _compute_series(window=window, bucket=bucket, seed=used_seed)
         data = {
             "window": window,
@@ -167,6 +244,125 @@ async def mission_load(
             response.headers["X-Cache-Key"] = cache_key
             response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
 
-    compute_ms = int((time.perf_counter() - start) * 1000)
-    response.headers["X-Compute-Time-ms"] = str(compute_ms)
+    response.headers["X-Compute-Time-ms"] = str(int((time.perf_counter() - start) * 1000))
+    return response
+
+
+@router.get("/reports/priority-distribution")
+async def priority_distribution(
+    request: Request,
+    window: str = Query("30d"),
+    buckets: int = Query(50, ge=5, le=200, description="Histogram bucket count (e.g., 10/50/100)"),
+    seed: Optional[int] = Query(None, description="Deterministic seed (enables caching)"),
+):
+    bad = _validate_window(request, window)
+    if bad is not None:
+        return bad
+
+    settings = get_settings()
+    redis: Redis = request.app.state.redis
+
+    cache_enabled = seed is not None
+    used_seed = seed if seed is not None else 42
+
+    start = time.perf_counter()
+    cache_key = cache_key_priority_distribution(window=window, buckets=buckets, seed=used_seed)
+
+    cached = None
+    if cache_enabled:
+        cached = await get_json(redis, cache_key)
+
+    if cached is not None:
+        inc_cache_hit()
+        data = cached["data"]
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "HIT"
+        response.headers["X-Cache-Key"] = cache_key
+        response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+    else:
+        inc_cache_miss()
+
+        # Issue #117: visible MISS delay
+        if cache_enabled:
+            await _delay_on_miss()
+
+        computed = _compute_priority_distribution(seed=used_seed, buckets=buckets)
+        data = {
+            "window": window,
+            "buckets": buckets,
+            "seed": used_seed if cache_enabled else None,
+            "generated_at": _now_iso(),
+            **computed,
+        }
+
+        if cache_enabled:
+            await set_json(redis, cache_key, {"data": data}, ttl_seconds=settings.cache_ttl_seconds)
+
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "MISS"
+        if cache_enabled:
+            response.headers["X-Cache-Key"] = cache_key
+            response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+
+    response.headers["X-Compute-Time-ms"] = str(int((time.perf_counter() - start) * 1000))
+    return response
+
+
+@router.get("/reports/category-breakdown")
+async def category_breakdown(
+    request: Request,
+    window: str = Query("30d"),
+    top_n: int = Query(10, ge=3, le=50, description="Return top N categories"),
+    seed: Optional[int] = Query(None, description="Deterministic seed (enables caching)"),
+):
+    bad = _validate_window(request, window)
+    if bad is not None:
+        return bad
+
+    settings = get_settings()
+    redis: Redis = request.app.state.redis
+
+    cache_enabled = seed is not None
+    used_seed = seed if seed is not None else 42
+
+    start = time.perf_counter()
+    cache_key = cache_key_category_breakdown(window=window, top_n=top_n, seed=used_seed)
+
+    cached = None
+    if cache_enabled:
+        cached = await get_json(redis, cache_key)
+
+    if cached is not None:
+        inc_cache_hit()
+        data = cached["data"]
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "HIT"
+        response.headers["X-Cache-Key"] = cache_key
+        response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+    else:
+        inc_cache_miss()
+
+        # Issue #117: visible MISS delay
+        if cache_enabled:
+            await _delay_on_miss()
+
+        computed = _compute_category_breakdown(seed=used_seed, top_n=top_n)
+        data = {
+            "window": window,
+            "top_n": top_n,
+            "seed": used_seed if cache_enabled else None,
+            "generated_at": _now_iso(),
+            **computed,
+        }
+
+        if cache_enabled:
+            await set_json(redis, cache_key, {"data": data}, ttl_seconds=settings.cache_ttl_seconds)
+
+        response = JSONResponse(ok(request, data), status_code=200)
+        response.headers["X-Cache"] = "MISS"
+        if cache_enabled:
+            response.headers["X-Cache-Key"] = cache_key
+            response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_seconds}"
+
+    response.headers["X-Compute-Time-ms"] = str(int((time.perf_counter() - start) * 1000))
     return response

--- a/backend/app/cache.py
+++ b/backend/app/cache.py
@@ -27,6 +27,13 @@ def cache_key_report(*, window: str, bucket: str) -> str:
 def cache_key_mission_load(*, window: str, bucket: str, seed: int) -> str:
     return f"cache:v1:mission_load:window={window}:bucket={bucket}:seed={seed}"
 
+def cache_key_priority_distribution(*, window: str, buckets: int, seed: int) -> str:
+    return f"cache:v1:priority_distribution:window={window}:buckets={buckets}:seed={seed}"
+
+
+def cache_key_category_breakdown(*, window: str, top_n: int, seed: int) -> str:
+    return f"cache:v1:category_breakdown:window={window}:top_n={top_n}:seed={seed}"
+
 
 async def get_json(redis: Redis, key: str) -> Optional[dict[str, Any]]:
     raw = await redis.get(key)


### PR DESCRIPTION
## What
- Added a demo-only delay on cache MISS for report endpoints to make cache proof obvious.
- HIT path remains fast.

## Why
- Improve demo clarity: MISS ~1.5–2.5s vs HIT <50ms.

## How to test
1. Call any report endpoint with a seed:
   - First call -> X-Cache: MISS, X-Compute-Time-ms noticeably high
   - Second call -> X-Cache: HIT, X-Compute-Time-ms low
